### PR TITLE
Project Owner form validation and other minor bug fixes

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -209,24 +209,24 @@ public class GitLabSCMNavigator extends SCMNavigator {
                 if (request.process(p.getPathWithNamespace(), new SCMNavigatorRequest.SourceLambda() {
                     @NonNull
                     @Override
-                    public SCMSource create(@NonNull String projectName) throws IOException, InterruptedException {
+                    public SCMSource create(@NonNull String projectPath) throws IOException, InterruptedException {
                         return new GitLabSCMSourceBuilder(
-                                getId() + "::" + projectName,
+                                getId() + "::" + projectPath,
                                 serverName,
                                 credentialsId,
                                 projectOwner,
-                                projectName
+                                projectPath
                         )
                                 .withTraits(traits)
                                 .build();
                     }
                 }, null, new SCMNavigatorRequest.Witness() {
                     @Override
-                    public void record(@NonNull String projectName, boolean isMatch) {
+                    public void record(@NonNull String projectPath, boolean isMatch) {
                         if (isMatch) {
-                            observer.getListener().getLogger().format("Proposing %s%n", projectName);
+                            observer.getListener().getLogger().format("Proposing %s%n", projectPath);
                         } else {
-                            observer.getListener().getLogger().format("Ignoring %s%n", projectName);
+                            observer.getListener().getLogger().format("Ignoring %s%n", projectPath);
                         }
                     }
                 })) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -194,7 +194,6 @@ public class GitLabSCMNavigator extends SCMNavigator {
                     // skip the user repos which includes all groups that they are a member of
                     continue;
                 }
-                count++;
                 // TODO needs review
                 // If repository is empty it throws an exception
                 try {
@@ -204,6 +203,7 @@ public class GitLabSCMNavigator extends SCMNavigator {
                             HyperlinkNote.encodeTo(p.getWebUrl(), p.getName()));
                     continue;
                 }
+                count++;
                 observer.getListener().getLogger().format("%nChecking project %s%n",
                         HyperlinkNote.encodeTo(p.getWebUrl(), p.getName()));
                 if (request.process(p.getPathWithNamespace(), new SCMNavigatorRequest.SourceLambda() {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceBuilder.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceBuilder.java
@@ -14,11 +14,14 @@ public class GitLabSCMSourceBuilder extends SCMSourceBuilder<GitLabSCMSourceBuil
     private final String credentialsId;
     @NonNull
     private final String projectOwner;
+    @NonNull
+    private final String projectPath;
 
     public GitLabSCMSourceBuilder(@CheckForNull String id, @CheckForNull String serverName,
                                   @CheckForNull String credentialsId, @NonNull String projectOwner,
                                   @NonNull String projectPath) {
         super(GitLabSCMSource.class, projectPath);
+        this.projectPath = projectPath;
         this.id = id;
         this.serverName = serverName;
         this.projectOwner = projectOwner;
@@ -31,27 +34,17 @@ public class GitLabSCMSourceBuilder extends SCMSourceBuilder<GitLabSCMSourceBuil
     }
 
     @CheckForNull
-    public String getServerName() {
-        return serverName;
-    }
-
-    @CheckForNull
     public String getCredentialsId() {
         return credentialsId;
-    }
-
-    @NonNull
-    public String getProjectOwner() {
-        return projectOwner;
     }
 
     @NonNull
     @Override
     public GitLabSCMSource build() {
         // projectName() should have been getProjectName()
-        GitLabSCMSource result = new GitLabSCMSource(serverName, projectOwner, projectName());
-        result.setId(getId());
-        result.setCredentialsId(getCredentialsId());
+        GitLabSCMSource result = new GitLabSCMSource(serverName, projectOwner, projectPath);
+        result.setId(id);
+        result.setCredentialsId(credentialsId);
         result.setTraits(traits());
         return result;
     }


### PR DESCRIPTION
* Added Form Validation for `projectOwner` field in GitLab Group Job Type (Folder organization)
* Other Minor bug fixes

This is a work in progress, working on implementing functions that will fix the logs in GitLab Group job type.

Here's some examples of form validation:
![Screenshot from 2019-07-17 19-37-05](https://user-images.githubusercontent.com/23079344/61383811-08264a80-a8cd-11e9-93db-d878ba09638b.png)
![Screenshot from 2019-07-17 19-37-34](https://user-images.githubusercontent.com/23079344/61383815-09577780-a8cd-11e9-81bd-54c8e75e3da2.png)
![Screenshot from 2019-07-17 19-42-44](https://user-images.githubusercontent.com/23079344/61383817-0a88a480-a8cd-11e9-99d7-a1556e4e1ad1.png)
