### PR TITLE
[JENKINS-58480] Impl SkipNotificationTrait

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/SkipNotificationsTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/SkipNotificationsTrait.java
@@ -1,0 +1,53 @@
+package io.jenkins.plugins.gitlabbranchsource;
+
+import hudson.Extension;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class SkipNotificationsTrait extends SCMSourceTrait {
+
+    /**
+     * Constructor for stapler.
+     */
+    @DataBoundConstructor
+    public SkipNotificationsTrait() {
+        //empty
+    }
+
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        if (context instanceof GitLabSCMSourceContext) {
+            GitLabSCMSourceContext ctx = (GitLabSCMSourceContext) context;
+            ctx.withNotificationsDisabled(true);
+        }
+    }
+
+    /**
+     * Our descriptor.
+     */
+    @Extension
+    @Symbol("skipNotifications")
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.SkipNotificationsTrait_displayName();
+        }
+
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return GitLabSCMSourceContext.class;
+        }
+
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return GitLabSCMSource.class;
+        }
+
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/TagDiscoveryTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/TagDiscoveryTrait.java
@@ -50,7 +50,7 @@ public class TagDiscoveryTrait extends SCMSourceTrait {
     /**
      * Our descriptor.
      */
-    @Symbol("gitHubTagDiscovery")
+    @Symbol("gitLabTagDiscovery")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
@@ -43,3 +43,4 @@ SSHCheckoutTrait.useAgentKey=- use build agent''s key -
 WebhookRegistrationTrait.disableHook=Disable hook management
 WebhookRegistrationTrait.displayName=Override hook management
 WebhookRegistrationTrait.useItemHook=Use item credentials for hook management
+SkipNotificationsTrait.displayName=Skip pipeline status notifications


### PR DESCRIPTION
This trait allows user to configure branch source to skip notifiying GitLab about pipeline status. Similar to https://wiki.jenkins.io/display/JENKINS/Skip+Notifications+Trait+Plugin