### PR TITLE
[JENKINS-58666, JENKINS-58730] Feature/trusted contributors

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait.java
@@ -27,7 +27,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- * A {@link Discovery} trait for GitLab that will discover merge requests from forks of the repository.
+ * A {@link Discovery} trait for GitLab that will discover merge requests from forks of the project.
  */
 public class ForkMergeRequestDiscoveryTrait extends SCMSourceTrait {
     /**
@@ -198,7 +198,7 @@ public class ForkMergeRequestDiscoveryTrait extends SCMSourceTrait {
         @NonNull
         @SuppressWarnings("unused") // stapler
         public SCMHeadAuthority<?, ?, ?> getDefaultTrust() {
-            return new TrustContributors();
+            return new TrustPermission();
         }
     }
 
@@ -248,15 +248,15 @@ public class ForkMergeRequestDiscoveryTrait extends SCMSourceTrait {
     }
 
     /**
-     * An {@link SCMHeadAuthority} that trusts contributors to the project.
+     * An {@link SCMHeadAuthority} that trusts Members to the project.
      */
-    public static class TrustContributors
+    public static class TrustMembers
             extends SCMHeadAuthority<GitLabSCMSourceRequest, MergeRequestSCMHead, MergeRequestSCMRevision> {
         /**
          * Constructor.
          */
         @DataBoundConstructor
-        public TrustContributors() {
+        public TrustMembers() {
         }
 
         /**
@@ -290,9 +290,8 @@ public class ForkMergeRequestDiscoveryTrait extends SCMSourceTrait {
             if(head.getOrigin().equals(SCMHeadOrigin.DEFAULT)) {
                return false;
             }
-
             assert request.getMembers() != null;
-            return request.getMembers().containsKey(head.getOriginOwner());
+            return request.isMember(head.getOriginOwner());
         }
     }
 
@@ -316,13 +315,13 @@ public class ForkMergeRequestDiscoveryTrait extends SCMSourceTrait {
         protected boolean checkTrusted(@NonNull GitLabSCMSourceRequest request, @NonNull MergeRequestSCMHead head)
                 throws IOException, InterruptedException {
             if (!head.getOrigin().equals(SCMHeadOrigin.DEFAULT)) {
-                AccessLevel permission = request.getPermissions(head.getOriginOwner());
+                AccessLevel permission = request.getPermission(head.getOriginOwner());
                 switch (permission) {
                     case MAINTAINER:
                     case DEVELOPER:
                     case OWNER:
                         return true;
-                    default:return false;
+                    default: return false;
                 }
             }
             return false;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.gitlabbranchsource;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.util.ListBoxModel;
-import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -282,7 +281,8 @@ public class ForkMergeRequestDiscoveryTrait extends SCMSourceTrait {
                 return SCMHeadOrigin.Fork.class.isAssignableFrom(originClass);
             }
 
-        }        /**
+        }
+        /**
          * {@inheritDoc}
          */
         @Override
@@ -296,7 +296,7 @@ public class ForkMergeRequestDiscoveryTrait extends SCMSourceTrait {
     }
 
     /**
-     * An {@link SCMHeadAuthority} that trusts those with write permission to the repository.
+     * An {@link SCMHeadAuthority} that trusts those with required permission to the project.
      */
     public static class TrustPermission
             extends SCMHeadAuthority<GitLabSCMSourceRequest, MergeRequestSCMHead, MergeRequestSCMRevision> {
@@ -312,16 +312,17 @@ public class ForkMergeRequestDiscoveryTrait extends SCMSourceTrait {
          * {@inheritDoc}
          */
         @Override
-        protected boolean checkTrusted(@NonNull GitLabSCMSourceRequest request, @NonNull MergeRequestSCMHead head)
-                throws IOException, InterruptedException {
+        protected boolean checkTrusted(@NonNull GitLabSCMSourceRequest request, @NonNull MergeRequestSCMHead head) {
             if (!head.getOrigin().equals(SCMHeadOrigin.DEFAULT)) {
                 AccessLevel permission = request.getPermission(head.getOriginOwner());
-                switch (permission) {
-                    case MAINTAINER:
-                    case DEVELOPER:
-                    case OWNER:
-                        return true;
-                    default: return false;
+                if(permission != null) {
+                    switch (permission) {
+                        case MAINTAINER:
+                        case DEVELOPER:
+                        case OWNER:
+                            return true;
+                        default: return false;
+                    }
                 }
             }
             return false;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMBuilder.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMBuilder.java
@@ -6,6 +6,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.damnhandy.uri.template.UriTemplate;
+import com.damnhandy.uri.template.impl.Operator;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Item;
@@ -131,14 +132,16 @@ public class GitLabSCMBuilder extends GitSCMBuilder<GitLabSCMBuilder> {
                         .build();
             }
         }
-        return UriTemplate.buildFromTemplate(serverUrl+'/'+projectPath)
+        return UriTemplate.buildFromTemplate(serverUrl + '/' + projectPath)
                 .literal(".git")
                 .build();
     }
 
     private String projectUrl(String projectPath) {
-        return UriTemplate.buildFromTemplate(serverUrl+'/'+projectPath)
+        return UriTemplate.buildFromTemplate(serverUrl)
+                .template("{/project*}")
                 .build()
+                .set("project", projectPath.split(Operator.PATH.getSeparator()))
                 .expand();
     }
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMBuilder.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMBuilder.java
@@ -54,6 +54,8 @@ public class GitLabSCMBuilder extends GitSCMBuilder<GitLabSCMBuilder> {
 
     private final String sshRemote;
 
+    private final String httpRemote;
+
     /**
      * Constructor
      *
@@ -65,14 +67,14 @@ public class GitLabSCMBuilder extends GitSCMBuilder<GitLabSCMBuilder> {
         super(
                 head,
                 revision,
-                checkoutUriTemplate(null, GitLabHelper.getServerUrlFromName(source.getServerName()), null, null, source.getProjectPath())
-                        .expand(),
+                source.getHttpRemote(),
                 source.getCredentialsId()
         );
         this.context = source.getOwner();
         serverUrl = StringUtils.defaultIfBlank(GitLabHelper.getServerUrlFromName(source.getServerName()), GitLabServer.GITLAB_SERVER_URL);
         projectPath = source.getProjectPath();
         sshRemote = source.getSshRemote();
+        httpRemote = source.getHttpRemote();
         // configure the ref specs
         withoutRefSpecs();
         String projectUrl;
@@ -103,6 +105,7 @@ public class GitLabSCMBuilder extends GitSCMBuilder<GitLabSCMBuilder> {
      */
     public static UriTemplate checkoutUriTemplate(@CheckForNull Item context,
                                                   @NonNull String serverUrl,
+                                                  @CheckForNull String httpRemote,
                                                   @CheckForNull String sshRemote,
                                                   @CheckForNull String credentialsId,
                                                   @NonNull String projectPath) {
@@ -132,6 +135,10 @@ public class GitLabSCMBuilder extends GitSCMBuilder<GitLabSCMBuilder> {
                         .build();
             }
         }
+        if(httpRemote != null) {
+            return UriTemplate.buildFromTemplate(httpRemote)
+                    .build();
+        }
         return UriTemplate.buildFromTemplate(serverUrl + '/' + projectPath)
                 .literal(".git")
                 .build();
@@ -153,8 +160,7 @@ public class GitLabSCMBuilder extends GitSCMBuilder<GitLabSCMBuilder> {
      */
     @NonNull
     public final UriTemplate checkoutUriTemplate() {
-        String credentialsId = credentialsId();
-        return checkoutUriTemplate(context, serverUrl, sshRemote, credentialsId, projectPath);
+        return checkoutUriTemplate(context, serverUrl, httpRemote, sshRemote, credentialsId(), projectPath);
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMBuilder.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMBuilder.java
@@ -92,12 +92,12 @@ public class GitLabSCMBuilder extends GitSCMBuilder<GitLabSCMBuilder> {
 
     /**
      * Returns a {@link UriTemplate} for checkout according to credentials configuration.
-     * Expects the parameters {@code owner} and {@code repository} to be populated before expansion.
      *
      * @param context       the context within which to resolve the credentials.
      * @param serverUrl     the server url
      * @param sshRemote     any valid SSH remote URL for the server.
      * @param credentialsId the credentials.
+     * @param projectPath   the full path to the project (with namespace).
      * @return a {@link UriTemplate}
      */
     public static UriTemplate checkoutUriTemplate(@CheckForNull Item context,

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -444,9 +444,7 @@ public class GitLabSCMNavigator extends SCMNavigator {
         @NonNull
         @SuppressWarnings("unused") // jelly
         public List<SCMTrait<? extends SCMTrait<?>>> getTraitsDefaults() {
-            List<SCMTrait<? extends SCMTrait<?>>> result = new ArrayList<>();
-            result.addAll(delegate.getTraitsDefaults());
-            return result;
+            return new ArrayList<>(delegate.getTraitsDefaults());
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -6,6 +6,7 @@ import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.UriTemplateBuilder;
+import com.damnhandy.uri.template.impl.Operator;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
@@ -449,8 +450,10 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 e.printStackTrace();
             }
         }
-        result.add(new GitLabLink("gitlab-project", UriTemplate.buildFromTemplate(GitLabHelper.getServerUrlFromName(serverName)+'/'+projectPath)
+        result.add(new GitLabLink("gitlab-project", UriTemplate.buildFromTemplate(GitLabHelper.getServerUrlFromName(serverName))
+                .template("{/project*}")
                 .build()
+                .set("project", projectPath.split(Operator.PATH.getSeparator()))
                 .expand()
         ));
         return result;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -218,7 +218,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     .newRequest(this, listener)) {
                 request.setGitLabApi(gitLabApi);
                 request.setProject(gitlabProject);
-                request.setMembers(gitLabApi.getProjectApi().getMembers(gitlabProject.getPathWithNamespace()));
+                request.setMembers(gitLabApi.getProjectApi().getAllMembers(gitlabProject.getPathWithNamespace()));
                 if (request.isFetchBranches()) {
                     request.setBranches(gitLabApi.getRepositoryApi().getBranches(gitlabProject));
                 }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -457,7 +457,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         List<Action> result = new ArrayList<>();
         if (head instanceof BranchSCMHead) {
             String branchUrl = UriTemplate.buildFromTemplate(GitLabHelper.getServerUrlFromName(serverName)+'/'+projectPath)
-                    .path("tree")
+                    .literal("/tree")
                     .path(UriTemplateBuilder.var("branch"))
                     .build()
                     .set("branch", head.getName())
@@ -475,7 +475,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             }
         } else if (head instanceof MergeRequestSCMHead) {
             String mergeUrl = UriTemplate.buildFromTemplate(GitLabHelper.getServerUrlFromName(serverName)+'/'+projectPath)
-                    .path("merge_requests")
+                    .literal("/merge_requests")
                     .path(UriTemplateBuilder.var("iid"))
                     .build()
                     .set("iid", ((MergeRequestSCMHead) head).getId())
@@ -490,7 +490,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             result.add(gitLabLink);
         } else if(head instanceof GitLabTagSCMHead) {
             String tagUrl = UriTemplate.buildFromTemplate(GitLabHelper.getServerUrlFromName(serverName)+'/'+projectPath)
-                    .path("tree")
+                    .literal("/tree")
                     .path(UriTemplateBuilder.var("tag"))
                     .build()
                     .set("tag", head.getName())

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -33,6 +33,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -260,7 +261,15 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                         if (request.process(new BranchSCMHead(branchName),
                                 (SCMSourceRequest.RevisionLambda<BranchSCMHead, BranchSCMRevision>) head ->
                                         new BranchSCMRevision(head, sha),
-                                this::createProbe,
+                                new SCMSourceRequest.ProbeLambda<BranchSCMHead, BranchSCMRevision>() {
+                                    @NonNull
+                                    @Override
+                                    public SCMSourceCriteria.Probe create(@NonNull BranchSCMHead head,
+                                                                          @Nullable BranchSCMRevision revision)
+                                            throws IOException {
+                                        return createProbe(head, revision);
+                                    }
+                                },
                                 (SCMSourceRequest.Witness) (head, revision, isMatch) -> {
                                     if (isMatch) {
                                         listener.getLogger().format("Met criteria%n");
@@ -274,13 +283,10 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     }
                     listener.getLogger().format("%n%d branches were processed%n", count);
                 }
-                if (request.isFetchMRs() && gitlabProject.getForkedFromProject() == null &&
-                        !(request.getForkMRStrategies().isEmpty()
-                                && request.getOriginMRStrategies().isEmpty())) {
+                if (request.isFetchMRs() && !request.isComplete()) {
                     int count = 0;
                     listener.getLogger().format("%nChecking merge requests..%n");
-                    Iterable<MergeRequest> mrs = request.getMergeRequests();
-                    for (MergeRequest mr : mrs) {
+                    for (MergeRequest mr : request.getMergeRequests()) {
                         // Since by default GitLab4j do not populate DiffRefs for a list of Merge Requests
                         // It is required to get the individual diffRef using the Iid.
                         final MergeRequest m =
@@ -300,12 +306,10 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                         String originOwner = m.getAuthor().getUsername();
                         // Origin project name will always the same as the source project name
                         String originProjectPath = projectPath;
-                        Set<ChangeRequestCheckoutStrategy> strategies = request.getMRStrategies(
-                                projectOwner.equalsIgnoreCase(originOwner)
-                                        && projectPath.equalsIgnoreCase(originProjectPath)
-                        );
+                        Map<Boolean, Set<ChangeRequestCheckoutStrategy>> strategies = request.getMRStrategies();
+                        boolean fork = !gitlabProject.getOwner().getUsername().equals(originOwner);
                         LOGGER.info(originOwner + " -> " + (request.isMember(originOwner) ? "TRUE" : "FALSE"));
-                        for (ChangeRequestCheckoutStrategy strategy : strategies) {
+                        for (ChangeRequestCheckoutStrategy strategy : strategies.get(fork)) {
                             if (request.process(new MergeRequestSCMHead(
                                             "MR-" + m.getIid() + (strategies.size() > 1 ? "-" + strategy.name()
                                                     .toLowerCase(Locale.ENGLISH) : ""),
@@ -332,7 +336,19 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                                                             m.getDiffRefs().getHeadSha()
                                                     )
                                             ),
-                                    this::createProbe,
+                                    new SCMSourceRequest.ProbeLambda<MergeRequestSCMHead, MergeRequestSCMRevision>() {
+                                        @NonNull
+                                        @Override
+                                        public SCMSourceCriteria.Probe create(@NonNull MergeRequestSCMHead head,
+                                                                              @Nullable MergeRequestSCMRevision revision)
+                                                throws IOException, InterruptedException {
+                                            boolean trusted = request.isTrusted(head);
+                                            if (!trusted) {
+                                                listener.getLogger().format("(not from a trusted source)%n");
+                                            }
+                                            return createProbe(trusted ? head : head.getTarget(), revision);
+                                        }
+                                    },
                                     (SCMSourceRequest.Witness) (head, revision, isMatch) -> {
                                         if (isMatch) {
                                             listener.getLogger().format("Met criteria%n");
@@ -420,8 +436,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
 
     @NonNull
     @Override
-    protected List<Action> retrieveActions(SCMSourceEvent event, @NonNull TaskListener listener)
-            throws IOException, InterruptedException {
+    protected List<Action> retrieveActions(SCMSourceEvent event, @NonNull TaskListener listener) {
         LOGGER.info(String.format("e, l..%s", Thread.currentThread().getName()));
         List<Action> result = new ArrayList<>();
         if (gitlabProject == null) {
@@ -443,8 +458,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
 
     @NonNull
     @Override
-    protected List<Action> retrieveActions(@NonNull SCMHead head, SCMHeadEvent event, @NonNull TaskListener listener)
-            throws IOException, InterruptedException {
+    protected List<Action> retrieveActions(@NonNull SCMHead head, SCMHeadEvent event, @NonNull TaskListener listener) {
         LOGGER.info(String.format("h, e, l..%s", Thread.currentThread().getName()));
         if (gitlabProject == null) {
             try {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -216,6 +216,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     .withTraits(getTraits())
                     .newRequest(this, listener)) {
                 request.setGitLabApi(gitLabApi);
+                request.setProject(gitlabProject);
+                request.setMembers(gitLabApi.getProjectApi().getMembers(gitlabProject.getPathWithNamespace()));
                 if (request.isFetchBranches()) {
                     request.setBranches(gitLabApi.getRepositoryApi().getBranches(gitlabProject));
                 }
@@ -610,6 +612,10 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         @Override
         public String getPronoun() {
             return Messages.GitLabSCMSource_Pronoun();
+        }
+
+        public String getSelectedServer(@QueryParameter String serverName) {
+            return serverName;
         }
 
         public ListBoxModel doFillServerNameItems(@AncestorInPath SCMSourceOwner context,

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -76,7 +76,6 @@ import org.gitlab4j.api.models.MergeRequest;
 import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.ProjectFilter;
 import org.gitlab4j.api.models.Tag;
-import org.gitlab4j.api.models.Visibility;
 import org.jenkins.ui.icon.IconSpec;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.AncestorInPath;
@@ -474,10 +473,12 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         }
         List<Action> result = new ArrayList<>();
         if (head instanceof BranchSCMHead) {
-            String branchUrl = UriTemplate.buildFromTemplate(GitLabHelper.getServerUrlFromName(serverName)+'/'+projectPath)
+            String branchUrl = UriTemplate.buildFromTemplate(GitLabHelper.getServerUrlFromName(serverName))
+                    .template("{/project*}")
                     .literal("/tree")
                     .path(UriTemplateBuilder.var("branch"))
                     .build()
+                    .set("project", projectPath.split(Operator.PATH.getSeparator()))
                     .set("branch", head.getName())
                     .expand();
             result.add(new ObjectMetadataAction(
@@ -492,10 +493,12 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 result.add(new PrimaryInstanceMetadataAction());
             }
         } else if (head instanceof MergeRequestSCMHead) {
-            String mergeUrl = UriTemplate.buildFromTemplate(GitLabHelper.getServerUrlFromName(serverName)+'/'+projectPath)
+            String mergeUrl = UriTemplate.buildFromTemplate(GitLabHelper.getServerUrlFromName(serverName))
+                    .template("{/project*}")
                     .literal("/merge_requests")
                     .path(UriTemplateBuilder.var("iid"))
                     .build()
+                    .set("project", projectPath.split(Operator.PATH.getSeparator()))
                     .set("iid", ((MergeRequestSCMHead) head).getId())
                     .expand();
             result.add(new ObjectMetadataAction(
@@ -507,10 +510,12 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             gitLabLink.setDisplayName("Merge Request");
             result.add(gitLabLink);
         } else if(head instanceof GitLabTagSCMHead) {
-            String tagUrl = UriTemplate.buildFromTemplate(GitLabHelper.getServerUrlFromName(serverName)+'/'+projectPath)
+            String tagUrl = UriTemplate.buildFromTemplate(GitLabHelper.getServerUrlFromName(serverName))
+                    .template("{/project*}")
                     .literal("/tree")
                     .path(UriTemplateBuilder.var("tag"))
                     .build()
+                    .set("project", projectPath.split(Operator.PATH.getSeparator()))
                     .set("tag", head.getName())
                     .expand();
             result.add(new ObjectMetadataAction(

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -557,7 +557,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             try (GitLabSCMSourceRequest request = new GitLabSCMSourceContext(null, SCMHeadObserver.none())
                     .withTraits(traits)
                     .newRequest(this, listener)) {
-                if(request.getMembers() == null) {
+                if(request.getMembers().isEmpty()) {
                     GitLabApi gitLabApi;
                     try {
                         gitLabApi = apiBuilder(serverName);

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -703,8 +703,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     return new StandardListBoxModel().includeEmptyValue();
                 }
                 try {
-                    for (Project p : gitLabApi.getProjectApi().getUserProjects(projectOwner, new ProjectFilter().withVisibility(
-                            Visibility.PUBLIC))) {
+                    for (Project p : gitLabApi.getProjectApi().getUserProjects(projectOwner, new ProjectFilter().withOwned(true))) {
                         result.add(p.getPathWithNamespace());
                     }
                 } catch (GitLabApiException e) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -304,6 +304,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                                 projectOwner.equalsIgnoreCase(originOwner)
                                         && projectPath.equalsIgnoreCase(originProjectPath)
                         );
+                        LOGGER.info(originOwner + " -> " + (request.isMember(originOwner) ? "TRUE" : "FALSE"));
                         for (ChangeRequestCheckoutStrategy strategy : strategies) {
                             if (request.process(new MergeRequestSCMHead(
                                             "MR-" + m.getIid() + (strategies.size() > 1 ? "-" + strategy.name()
@@ -730,7 +731,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     new BranchDiscoveryTrait(true, false),
                     new OriginMergeRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE)),
                     new ForkMergeRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE),
-                            new ForkMergeRequestDiscoveryTrait.TrustContributors())
+                            new ForkMergeRequestDiscoveryTrait.TrustMembers())
             );
         }
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -99,6 +99,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     private String credentialsId;
     private List<SCMSourceTrait> traits = new ArrayList<>();
     private transient String sshRemote;
+
+    private transient String httpRemote;
     private transient Project gitlabProject;
 
     @DataBoundConstructor
@@ -118,6 +120,14 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
 
     public String getProjectPath() {
         return projectPath;
+    }
+
+    public String getHttpRemote() {
+        return httpRemote;
+    }
+
+    public void setHttpRemote(String httpRemote) {
+        this.httpRemote = httpRemote;
     }
 
     public String getSshRemote() {
@@ -140,7 +150,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
 
     @Override
     public String getRemote() {
-        return GitLabSCMBuilder.checkoutUriTemplate(getOwner(), GitLabHelper.getServerUrlFromName(serverName), getSshRemote(), getCredentialsId(), projectPath)
+        return GitLabSCMBuilder.checkoutUriTemplate(getOwner(), GitLabHelper.getServerUrlFromName(serverName), getHttpRemote(), getSshRemote(), getCredentialsId(), projectPath)
                 .expand();
     }
 
@@ -214,6 +224,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             }
             LOGGER.info(String.format("c, o, e, l..%s", Thread.currentThread().getName()));
             sshRemote = gitlabProject.getSshUrlToRepo();
+            httpRemote = gitlabProject.getHttpUrlToRepo();
             try (GitLabSCMSourceRequest request = new GitLabSCMSourceContext(criteria, observer)
                     .withTraits(getTraits())
                     .newRequest(this, listener)) {
@@ -428,7 +439,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     @Override
     protected Set<String> retrieveRevisions(@NonNull TaskListener listener) throws IOException, InterruptedException {
         // don't pass through to git, instead use the super.super behaviour
-        Set<String> revisions = new HashSet<String>();
+        Set<String> revisions = new HashSet<>();
         for (SCMHead head : retrieve(listener)) {
             revisions.add(head.getName());
         }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
@@ -334,18 +334,18 @@ public class GitLabSCMSourceRequest extends SCMSourceRequest {
     }
 
     /**
-     * Returns the project {@link Member} or {@code null} if those details have not been provided yet.
+     * Returns the Map of project {@link Member} or {@code null} if those details have not been provided yet.
      *
-     * @return the project {@link Member} or {@code null} if those details have not been provided yet.
+     * @return the Map of project {@link Member} or {@code null} if those details have not been provided yet.
      */
     public final HashMap<String, AccessLevel> getMembers() {
         return members;
     }
 
     /**
-     * Provides the set of project {@link Member}.
+     * Provides the Map of project {@link Member} username and {@link Member}.
      *
-     * @param members the set of project {@link Member}.
+     * @param members the list of project {@link Member}.
      */
     public final void setMembers(@CheckForNull List<Member> members) {
         this.members = new HashMap<>();

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
@@ -345,12 +345,12 @@ public class GitLabSCMSourceRequest extends SCMSourceRequest {
     /**
      * Provides the Map of project {@link Member} username and {@link Member}.
      *
-     * @param members the list of project {@link Member}.
+     * @param membersList the list of project {@link Member}.
      */
-    public final void setMembers(@CheckForNull List<Member> members) {
+    public final void setMembers(@CheckForNull List<Member> membersList) {
         this.members = new HashMap<>();
-        if(members != null) {
-            for(Member m : members) {
+        if(membersList != null) {
+            for(Member m : membersList) {
                 this.members.put(m.getUsername(), m.getAccessLevel());
             }
         }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
@@ -387,9 +387,8 @@ public class GitLabSCMSourceRequest extends SCMSourceRequest {
     /**
      * Returns the permissions of the supplied user.
      *
-     * @return the permissions of the supplied user.
-     * @throws IOException if the permissions could not be retrieved.
-     * @throws InterruptedException if interrupted while retrieving the permissions.
+     * @param username the username of MR author
+     * @return {@link AccessLevel} the permissions of the supplied user.
      */
     public AccessLevel getPermission(String username){
         if(getGitLabApi() == null || getMembers() == null) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
@@ -102,12 +102,6 @@ public class GitLabSCMSourceRequest extends SCMSourceRequest {
      */
     @CheckForNull
     private GitLabApi gitLabApi;
-    /**
-     * The resolved permissions keyed by user.
-     */
-    @NonNull
-    @GuardedBy("self")
-    private final Map<String, AccessLevel> permissions = new HashMap<>();
 
     /**
      * Constructor.

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
@@ -89,8 +89,7 @@ public class GitLabSCMSourceRequest extends SCMSourceRequest {
     /**
      * The list of project {@link Member} or {@code null} if not provided.
      */
-    @CheckForNull
-    private HashMap<String, AccessLevel> members;
+    private HashMap<String, AccessLevel> members = new HashMap<>();
     /**
      * The project.
      */
@@ -348,7 +347,7 @@ public class GitLabSCMSourceRequest extends SCMSourceRequest {
      * @param membersList the list of project {@link Member}.
      */
     public final void setMembers(@CheckForNull List<Member> membersList) {
-        this.members = new HashMap<>();
+        this.members.clear();
         if(membersList != null) {
             for(Member m : membersList) {
                 this.members.put(m.getUsername(), m.getAccessLevel());

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
@@ -18,7 +18,6 @@ import jenkins.scm.api.SCMHeadOrigin;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 import jenkins.scm.api.trait.SCMSourceRequest;
-import net.jcip.annotations.GuardedBy;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.Branch;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
@@ -26,8 +26,11 @@ import org.gitlab4j.api.models.Member;
 import org.gitlab4j.api.models.MergeRequest;
 import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GitLabSCMSourceRequest extends SCMSourceRequest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GitLabSCMSourceRequest.class);
     /**
      * {@code true} if branch details need to be fetched.
      */
@@ -388,7 +391,7 @@ public class GitLabSCMSourceRequest extends SCMSourceRequest {
      * @throws IOException if the permissions could not be retrieved.
      * @throws InterruptedException if interrupted while retrieving the permissions.
      */
-    public AccessLevel getPermissions(String username){
+    public AccessLevel getPermission(String username){
         if(getGitLabApi() == null || getMembers() == null) {
             return null;
         }
@@ -396,6 +399,13 @@ public class GitLabSCMSourceRequest extends SCMSourceRequest {
             return getMembers().get(username);
         }
         return null;
+    }
+
+    public boolean isMember(String username) {
+        if(getMembers() == null) {
+            throw new NullPointerException("No members! :O");
+        }
+        return getMembers().containsKey(username);
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/MergeRequestSCMRevision.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/MergeRequestSCMRevision.java
@@ -9,6 +9,9 @@ public class MergeRequestSCMRevision extends ChangeRequestSCMRevision<MergeReque
 
     private BranchSCMRevision origin;
 
+    private final @NonNull String baseHash;
+    private final @NonNull String headHash;
+
     /**
      * Constructor.
      *
@@ -21,7 +24,19 @@ public class MergeRequestSCMRevision extends ChangeRequestSCMRevision<MergeReque
             @NonNull BranchSCMRevision target,
             @NonNull BranchSCMRevision origin) {
         super(head, target);
+        this.baseHash = target.getHash();
+        this.headHash = origin.getHash();
         this.origin = origin;
+    }
+
+    @NonNull
+    public String getBaseHash() {
+        return baseHash;
+    }
+
+    @NonNull
+    public String getHeadHash() {
+        return headHash;
     }
 
     @Exported

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabSCMPipelineStatusNotifier.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabSCMPipelineStatusNotifier.java
@@ -132,6 +132,7 @@ public class GitLabSCMPipelineStatusNotifier {
         }
         try {
             GitLabApi gitLabApi = GitLabHelper.apiBuilder(source.getServerName());
+            LOGGER.info("COMMIT: " + hash);
             gitLabApi.getCommitsApi().addCommitStatus(
                     source.getProjectPath(),
                     hash,

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServers.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServers.java
@@ -83,7 +83,7 @@ public class GitLabServers extends GlobalConfiguration implements PersistentDesc
     /**
      * Gets descriptor of {@link GitLabPersonalAccessTokenCreator}
      *
-     * returns the list of descriptors
+     * @return the list of descriptors
      */
     public List<Descriptor> actions() {
         return Collections.singletonList(Jenkins.get().getDescriptor(GitLabPersonalAccessTokenCreator.class));

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/TrustEveryone/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/TrustEveryone/config.jelly
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:description>${%blurb}</f:description>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/TrustEveryone/config.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/TrustEveryone/config.properties
@@ -1,0 +1,1 @@
+blurb=<div class="warning">This option is generally insecure. See help button.</div>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/TrustMembers/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/TrustMembers/config.jelly
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:description>${%blurb}</f:description>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/TrustMembers/config.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/TrustMembers/config.properties
@@ -1,0 +1,1 @@
+blurb=<div class="warning">This option may be insecure in some environments. See help button.</div>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/TrustPermission/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/TrustPermission/config.jelly
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:description>${%blurb}</f:description>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/TrustPermission/config.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/TrustPermission/config.properties
@@ -1,0 +1,1 @@
+blurb=Trusted Members with Developer / Maintainer / Owner access level

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/help-trust.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait/help-trust.html
@@ -13,22 +13,28 @@
     <dl>
         <dt>Nobody</dt>
         <dd>
-            merge requests from forks will all be treated as untrusted. This means that where Jenkins requires a
+            Merge requests from forks will all be treated as untrusted. This means that where Jenkins requires a
             trusted file (e.g. <code>Jenkinsfile</code>) the contents of that file will be retrieved from the
             target branch on the origin project and not from the merge request branch on the fork project.
         </dd>
-        <dt>Contributors</dt>
+        <dt>Members</dt>
         <dd>
-            merge requests from collaborators to the origin project will be treated as trusted, all other merge
+            Merge requests from collaborators to the origin project will be treated as trusted, all other merge
             requests from fork repositories will be treated as untrusted.
             Note that if credentials used by Jenkins for scanning the project does not have permission to
             query the list of contributors to the origin project then only the origin account will be treated
             as trusted - i.e. this will fall back to <code>Nobody</code>.
         </dd>
+        <dt>Trusted Members</dt>
+        <dd>
+            Merge requests forks will be treated as trusted if and only if the fork owner has either Developer or
+            Maintainer or Owner Access Level in the origin project.
+            <strong>This is the recommended policy.</strong>
+        </dd>
         <dt>Everyone</dt>
         <dd>
             All merge requests from forks will be treated as trusted. <strong>NOTE:</strong> this option can be dangerous
-            if used on a public project hosted on a Gitea instance that allows signup.
+            if used on a public project hosted on a GitLab instance.
         </dd>
     </dl>
 </div>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
@@ -4,7 +4,7 @@ BranchDiscoveryTrait.authorityDisplayName=Trust origin branches
 BranchDiscoveryTrait.displayName=Discover branches
 BranchDiscoveryTrait.excludeMRs=Only branches that are not also filed as MRs
 BranchDiscoveryTrait.onlyMRs=Only branches that are also filed as MRs
-ForkMergeRequestDiscoveryTrait.contributorsDisplayName=Contributors
+ForkMergeRequestDiscoveryTrait.contributorsDisplayName=Members
 ForkMergeRequestDiscoveryTrait.displayName=Discover merge requests from forks
 ForkMergeRequestDiscoveryTrait.everyoneDisplayName=Everyone
 ForkMergeRequestDiscoveryTrait.headAndMerge=Both the current merge request revision and the merge request merged with \
@@ -12,6 +12,7 @@ ForkMergeRequestDiscoveryTrait.headAndMerge=Both the current merge request revis
 ForkMergeRequestDiscoveryTrait.headOnly=The current merge request revision
 ForkMergeRequestDiscoveryTrait.mergeOnly=Merging the merge request with the current target branch revision
 ForkMergeRequestDiscoveryTrait.nobodyDisplayName=Nobody
+ForkMergeRequestDiscoveryTrait.permissionsDisplayName=Trusted Members
 
 GitLabTagSCMHead.Pronoun=Tag
 SubGroupProjectDiscoveryTrait.displayName=Discover Projects located inside subgroups

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
@@ -4,13 +4,14 @@ BranchDiscoveryTrait.authorityDisplayName=Trust origin branches
 BranchDiscoveryTrait.displayName=Discover branches
 BranchDiscoveryTrait.excludeMRs=Only branches that are not also filed as MRs
 BranchDiscoveryTrait.onlyMRs=Only branches that are also filed as MRs
-ForkMergeRequestDiscoveryTrait.contributorsDisplayName=Members
+
 ForkMergeRequestDiscoveryTrait.displayName=Discover merge requests from forks
-ForkMergeRequestDiscoveryTrait.everyoneDisplayName=Everyone
 ForkMergeRequestDiscoveryTrait.headAndMerge=Both the current merge request revision and the merge request merged with \
-  the current target branch revision
+the current target branch revision
 ForkMergeRequestDiscoveryTrait.headOnly=The current merge request revision
 ForkMergeRequestDiscoveryTrait.mergeOnly=Merging the merge request with the current target branch revision
+ForkMergeRequestDiscoveryTrait.contributorsDisplayName=Members
+ForkMergeRequestDiscoveryTrait.everyoneDisplayName=Everyone
 ForkMergeRequestDiscoveryTrait.nobodyDisplayName=Nobody
 ForkMergeRequestDiscoveryTrait.permissionsDisplayName=Trusted Members
 


### PR DESCRIPTION
Based on @oleg-nenashev suggestion added the trusted contributors (or members) permission for Fork Merge Requests Trait. The current implementation of permission in `GitLabSCMSourceRequest` works, as is correctly logged with `mr author` and it's corresponding permission before the MR indexing. But the `ForkMergeRequestTrait` doesn't work in itself. Tried with different trust like `member`, `nobody` etc. It doesn't work for any case. So there must be some problem in our implementation of ForkMRTrait.