### PR TITLE
[JENKINS-58695] Extend subgroup projects filter for user

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -57,7 +57,6 @@ import org.gitlab4j.api.GitLabApiException;
 import org.gitlab4j.api.models.GroupProjectsFilter;
 import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.ProjectFilter;
-import org.gitlab4j.api.models.Visibility;
 import org.jenkins.ui.icon.IconSpec;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.AncestorInPath;
@@ -184,10 +183,10 @@ public class GitLabSCMNavigator extends SCMNavigator {
             List<Project> projects;
             if(gitlabOwner instanceof GitLabUser) {
                 // Even returns the group projects owned by the user
-                if(gitLabApi.getAuthToken().equals("")) {
-                    projects = gitLabApi.getProjectApi().getUserProjects(projectOwner, new ProjectFilter().withVisibility(Visibility.PUBLIC));
-                } else {
+                if(request.wantSubgroupProjects()) {
                     projects = gitLabApi.getProjectApi().getOwnedProjects();
+                } else {
+                    projects = gitLabApi.getProjectApi().getUserProjects(projectOwner, new ProjectFilter().withOwned(true));
                 }
             } else {
                 GroupProjectsFilter groupProjectsFilter = new GroupProjectsFilter();

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
@@ -14,7 +14,7 @@ ForkMergeRequestDiscoveryTrait.mergeOnly=Merging the merge request with the curr
 ForkMergeRequestDiscoveryTrait.nobodyDisplayName=Nobody
 
 GitLabTagSCMHead.Pronoun=Tag
-SubGroupProjectDiscoveryTrait.displayName=Discover Projects located inside subgroups
+SubGroupProjectDiscoveryTrait.displayName=Discover group/subgroup projects
 TagDiscoveryTrait.authorityDisplayName=Trust origin tags
 TagDiscoveryTrait.displayName=Discover tags
 GitLabSCMSource.TagCategory=Tags

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/SubGroupProjectDiscoveryTrait/help.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/SubGroupProjectDiscoveryTrait/help.html
@@ -1,0 +1,3 @@
+<div>
+    Discovers all subgroup/group projects for a owner (User/Group/Subgroup).
+</div>


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/JENKINS-58695.

Just for reference I am writing here that I will add more configurations like accessing PRIVATE/PUBLIC/INTERNAL or some search pattern etc.