### PR TITLE
[JENKINS-58722] fixed sshremote url

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMBuilder.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMBuilder.java
@@ -127,7 +127,7 @@ public class GitLabSCMBuilder extends GitSCMBuilder<GitLabSCMBuilder> {
                     )
             );
             if (credentials instanceof SSHUserPrivateKey) {
-                return UriTemplate.buildFromTemplate("ssh://" + sshRemote)
+                return UriTemplate.buildFromTemplate(sshRemote)
                         .build();
             }
         }


### PR DESCRIPTION
The ssh remote url was incorrect. Based on @casz suggestion made the changes and it fixes checkout over ssh. Tested with ssh keys generated from **https://8gwifi.org/sshfunctions.jsp**.