### PR TITLE
[JENKINS - 58748, 58796, 58797] Jenkins rebuild comment and mr event fixes

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMCommentEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMCommentEvent.java
@@ -1,0 +1,91 @@
+package io.jenkins.plugins.gitlabbranchsource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMHeadOrigin;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
+import org.gitlab4j.api.GitLabApi;
+import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.webhook.NoteEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GitLabMergeRequestSCMCommentEvent extends AbstractGitLabSCMHeadEvent<NoteEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GitLabSCMSource.class);
+
+    public static String TRIGGER_COMMENT = "jenkins rebuild";
+
+    public GitLabMergeRequestSCMCommentEvent(NoteEvent noteEvent, String origin) {
+        super(Type.UPDATED, noteEvent, origin);
+    }
+
+    @Override
+    public boolean isMatch(@NonNull GitLabSCMNavigator navigator) {
+        return navigator.getNavigatorProjects().contains(getPayload().getProject().getPathWithNamespace());
+    }
+
+    @Override
+    public boolean isMatch(@NonNull GitLabSCMSource source) {
+        return getPayload().getMergeRequest().getTargetProjectId().equals(source.getProjectId());
+    }
+
+    @NonNull
+    @Override
+    protected Map<SCMHead, SCMRevision> headsFor(GitLabSCMSource source) {
+        Map<SCMHead, SCMRevision> result = new HashMap<>();
+        try (GitLabSCMSourceRequest request = new GitLabSCMSourceContext(null, SCMHeadObserver.none())
+                .withTraits(source.getTraits())
+                .newRequest(source, null)) {
+            GitLabApi gitLabApi = GitLabHelper.apiBuilder(source.getServerName());
+            Map<Boolean, Set<ChangeRequestCheckoutStrategy>> strategies = request.getMRStrategies();
+            boolean fork = !getPayload().getObjectAttributes().getProjectId().equals(getPayload().getProjectId());
+            String originOwner = gitLabApi.getUserApi().getUser(getPayload().getMergeRequest().getAuthorId()).getUsername();
+            String originProjectPath = gitLabApi.getProjectApi()
+                    .getProject(getPayload().getMergeRequest().getSourceProjectId()).getPathWithNamespace();
+            for (ChangeRequestCheckoutStrategy strategy : strategies.get(fork)) {
+                MergeRequestSCMHead h = new MergeRequestSCMHead(
+                        "MR-" + getPayload().getMergeRequest().getIid() + (strategies.size() > 1 ? "-" + strategy.name()
+                                .toLowerCase(Locale.ENGLISH) : ""),
+                        getPayload().getMergeRequest().getIid() ,
+                        new BranchSCMHead(getPayload().getMergeRequest().getTargetBranch()),
+                        ChangeRequestCheckoutStrategy.MERGE,
+                        fork
+                                ? new SCMHeadOrigin.Fork(originProjectPath)
+                                : SCMHeadOrigin.DEFAULT,
+                        originOwner,
+                        originProjectPath,
+                        getPayload().getMergeRequest().getSourceBranch()
+                );
+                result.put(h, new MergeRequestSCMRevision(
+                        h,
+                        new BranchSCMRevision(
+                                h.getTarget(),
+                                "HEAD"
+                        ),
+                        new BranchSCMRevision(
+                                new BranchSCMHead(h.getOriginName()),
+                                getPayload().getMergeRequest().getLastCommit().getId()
+                        )
+                ));
+            }
+        } catch (IOException | NoSuchFieldException | GitLabApiException e) {
+            e.printStackTrace();
+        }
+        return result;
+    }
+
+    @NonNull
+    @Override
+    public String getSourceName() {
+        return getPayload().getProject().getPathWithNamespace();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMCommentEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMCommentEvent.java
@@ -22,7 +22,7 @@ public class GitLabMergeRequestSCMCommentEvent extends AbstractGitLabSCMHeadEven
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GitLabSCMSource.class);
 
-    public static String TRIGGER_COMMENT = "jenkins rebuild";
+    public static final String TRIGGER_COMMENT = "jenkins rebuild";
 
     public GitLabMergeRequestSCMCommentEvent(NoteEvent noteEvent, String origin) {
         super(Type.UPDATED, noteEvent, origin);

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMEvent.java
@@ -23,15 +23,13 @@ public class GitLabMergeRequestSCMEvent extends AbstractGitLabSCMHeadEvent<Merge
 
     // TODO: Take care of "locked" state
     private static Type typeOf(MergeRequestEvent mrEvent) {
-        switch (mrEvent.getObjectAttributes().getState()) {
-            case "opened":
-                return Type.CREATED;
-            case "closed":
-                return Type.REMOVED;
-            case "reopened":
-            default:
-                return Type.UPDATED;
+        if(mrEvent.getObjectAttributes().getState().equals("closed")) {
+            return Type.REMOVED;
+        } else if(mrEvent.getObjectAttributes().getState().equals("opened")
+                && mrEvent.getObjectAttributes().getCreatedAt().equals(mrEvent.getObjectAttributes().getUpdatedAt())) {
+            return Type.CREATED;
         }
+        return Type.UPDATED;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -571,6 +571,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     public SCMRevision getTrustedRevision(@NonNull SCMRevision revision, @NonNull TaskListener listener) {
         if(revision instanceof MergeRequestSCMRevision) {
             MergeRequestSCMHead head = (MergeRequestSCMHead) revision.getHead();
+            LOGGER.info("Trusted Revision: "+isTrusted);
             if (isTrusted) {
                 return revision;
             }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebhookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebhookCreator.java
@@ -120,6 +120,7 @@ public class GitLabWebhookCreator {
         enabledHooks.setPushEvents(true);
         enabledHooks.setMergeRequestsEvents(true);
         enabledHooks.setTagPushEvents(true);
+        enabledHooks.setNoteEvents(true);
         enabledHooks.setEnableSslVerification(false);
         // TODO add secret token, add more events give option for sslVerification
         return enabledHooks;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebhookListener.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebhookListener.java
@@ -4,6 +4,7 @@ package io.jenkins.plugins.gitlabbranchsource;
 import java.util.logging.Logger;
 import jenkins.scm.api.SCMHeadEvent;
 import org.gitlab4j.api.webhook.MergeRequestEvent;
+import org.gitlab4j.api.webhook.NoteEvent;
 import org.gitlab4j.api.webhook.PushEvent;
 import org.gitlab4j.api.webhook.TagPushEvent;
 import org.gitlab4j.api.webhook.WebHookListener;
@@ -16,6 +17,19 @@ public class GitLabWebhookListener implements WebHookListener {
 
     public GitLabWebhookListener(String origin) {
         this.origin = origin;
+    }
+
+    @Override
+    public void onNoteEvent(NoteEvent event) {
+        LOGGER.info("NOTE EVENT");
+        LOGGER.info(event.toString());
+        if(event.getObjectAttributes().getNoteableType().equals(NoteEvent.NoteableType.MERGE_REQUEST)
+                && event.getObjectAttributes().getNote().equalsIgnoreCase(
+                        GitLabMergeRequestSCMCommentEvent.TRIGGER_COMMENT
+        )) {
+            GitLabMergeRequestSCMCommentEvent trigger = new GitLabMergeRequestSCMCommentEvent(event, origin);
+            SCMHeadEvent.fireNow(trigger);
+        }
     }
 
     @Override


### PR DESCRIPTION
* `Jenkins rebuild` comment works for ORIGIN and FORK MRs. But it doesn't work for same revision. As Jenkins says it is in the same revision. Even when build fails for some weird reason or cancellation. You cannot rebuild revision. 
* MR Event for updated type was not working, fixed it. The `typeOf` method needed some fix.
* `getTrustedRevision` method always returned false for Forked MRs. Perphaps the source request wasn't working properly as criteria was null (idk exactly). So created a transient `isTrusted` variable in SCMSource. So now `getTrustedRevision` works as intended.