### PR TITLE
[JENKINS-58829] Add symbol annotations to branch, fork MRs and tag dicovery traits

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/BranchDiscoveryTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/BranchDiscoveryTrait.java
@@ -17,6 +17,7 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.trait.Discovery;
 import org.gitlab4j.api.models.MergeRequest;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -116,6 +117,7 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
     /**
      * Our descriptor.
      */
+    @Symbol("gitLabBranchDiscovery")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
@@ -177,6 +179,7 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
          * Out descriptor.
          */
         @Extension
+        @Symbol("gitLabBranchHeadAuthority")
         public static class DescriptorImpl extends SCMHeadAuthorityDescriptor {
             /**
              * {@inheritDoc}

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/ForkMergeRequestDiscoveryTrait.java
@@ -21,6 +21,7 @@ import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
 import org.gitlab4j.api.models.AccessLevel;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -129,6 +130,7 @@ public class ForkMergeRequestDiscoveryTrait extends SCMSourceTrait {
     /**
      * Our descriptor.
      */
+    @Symbol("gitLabForkDiscovery")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
@@ -225,6 +227,7 @@ public class ForkMergeRequestDiscoveryTrait extends SCMSourceTrait {
         /**
          * Our descriptor.
          */
+        @Symbol("gitLabTrustNobody")
         @Extension
         public static class DescriptorImpl extends SCMHeadAuthorityDescriptor {
 
@@ -261,6 +264,7 @@ public class ForkMergeRequestDiscoveryTrait extends SCMSourceTrait {
         /**
          * Our descriptor.
          */
+        @Symbol("gitLabTrustMembers")
         @Extension
         public static class DescriptorImpl extends SCMHeadAuthorityDescriptor {
 
@@ -331,6 +335,7 @@ public class ForkMergeRequestDiscoveryTrait extends SCMSourceTrait {
         /**
          * Our descriptor.
          */
+        @Symbol("gitLabTrustPermissions")
         @Extension
         public static class DescriptorImpl extends SCMHeadAuthorityDescriptor {
             /**
@@ -365,6 +370,7 @@ public class ForkMergeRequestDiscoveryTrait extends SCMSourceTrait {
         /**
          * Our descriptor.
          */
+        @Symbol("gitLabTrustEveryone")
         @Extension
         public static class DescriptorImpl extends SCMHeadAuthorityDescriptor {
 


### PR DESCRIPTION
This is a community reported bug by Peter Leibiger. The symbol annotations are required for JCasC. Note: Annotation for Tag Discovery was already implemented.