### PR TITLE
Use GitHub as source of documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
     </developer>
   </developers>
 
-  <url>https://wiki.jenkins.io/display/JENKINS/GitLab+Branch+Source+Plugin</url>
+  <url>https://github.com/jenkinsci/gitlab-branch-source-plugin</url>
 
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/WEBSITE-406 -- pugins that have better docs in GitHub than Wiki should use GitHub.