### PR TITLE
Fix IndexOutOfBounds on push of new branch

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/AbstractGitLabSCMHeadEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/AbstractGitLabSCMHeadEvent.java
@@ -5,6 +5,7 @@ import hudson.scm.SCM;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 import org.gitlab4j.api.webhook.AbstractPushEvent;
 
@@ -19,7 +20,7 @@ public abstract class AbstractGitLabSCMHeadEvent<E> extends SCMHeadEvent<E> {
 
     private static final Logger LOGGER = Logger.getLogger(AbstractGitLabSCMHeadEvent.class.getName());
 
-    private static final String NONE_HASH_PATTERN = "^0+$";
+    private static final Pattern NONE_HASH_PATTERN = Pattern.compile("^0+$");
 
     static <E extends AbstractPushEvent> Type typeOf(E pushEvent) {
         Type result;
@@ -39,7 +40,7 @@ public abstract class AbstractGitLabSCMHeadEvent<E> extends SCMHeadEvent<E> {
     }
 
     private static boolean isPresent(String ref) {
-        return !(ref.matches(NONE_HASH_PATTERN));
+        return !(NONE_HASH_PATTERN.matcher(ref).matches());
     }
 
     public AbstractGitLabSCMHeadEvent(Type type, E createEvent, String origin) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/AbstractGitLabSCMHeadEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/AbstractGitLabSCMHeadEvent.java
@@ -6,15 +6,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-
-import org.gitlab4j.api.webhook.AbstractPushEvent;
-
 import javax.annotation.Nonnull;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadEvent;
 import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
+import org.gitlab4j.api.webhook.AbstractPushEvent;
 
 public abstract class AbstractGitLabSCMHeadEvent<E> extends SCMHeadEvent<E> {
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabPushSCMEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabPushSCMEvent.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.gitlabbranchsource;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 import java.util.Map;
-
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMRevision;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabPushSCMEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabPushSCMEvent.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.gitlabbranchsource;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMNavigator;
@@ -15,33 +14,8 @@ import org.gitlab4j.api.webhook.PushEvent;
 
 public class GitLabPushSCMEvent extends AbstractGitLabSCMHeadEvent<PushEvent> {
 
-    private static final Logger LOGGER = Logger.getLogger(GitLabPushSCMEvent.class.getName());
-
-    private static final String NULL_REV = "0000000000000000000000000000000000000000";
-
     public GitLabPushSCMEvent(PushEvent pushEvent, String origin) {
         super(typeOf(pushEvent), pushEvent, origin);
-    }
-
-    private static Type typeOf(PushEvent pushEvent) {
-        Type result;
-        boolean hasBefore = isPresent(pushEvent.getBefore());
-        boolean hasAfter = isPresent(pushEvent.getAfter());
-        if (hasBefore && hasAfter) {
-            result = Type.UPDATED;
-        } else if (hasAfter) {
-            result = Type.CREATED;
-        } else if (hasBefore) {
-            result = Type.REMOVED;
-        } else {
-            LOGGER.warning("Received push event with both \"before\" and \"after\" set to non-existing revision. Assuming removal.");
-            result = Type.REMOVED;
-        }
-        return result;
-    }
-
-    private static boolean isPresent(String ref) {
-        return !(ref.equals(NULL_REV));
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabPushSCMEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabPushSCMEvent.java
@@ -3,6 +3,8 @@ package io.jenkins.plugins.gitlabbranchsource;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 import java.util.Map;
+import java.util.logging.Logger;
+
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMRevision;
@@ -13,18 +15,33 @@ import org.gitlab4j.api.webhook.PushEvent;
 
 public class GitLabPushSCMEvent extends AbstractGitLabSCMHeadEvent<PushEvent> {
 
+    private static final Logger LOGGER = Logger.getLogger(GitLabPushSCMEvent.class.getName());
+
+    private static final String NULL_REV = "0000000000000000000000000000000000000000";
+
     public GitLabPushSCMEvent(PushEvent pushEvent, String origin) {
         super(typeOf(pushEvent), pushEvent, origin);
     }
 
     private static Type typeOf(PushEvent pushEvent) {
-        if (!pushEvent.getCommits().get(0).getAdded().isEmpty()) {
-            return Type.CREATED;
+        Type result;
+        boolean hasBefore = isPresent(pushEvent.getBefore());
+        boolean hasAfter = isPresent(pushEvent.getAfter());
+        if (hasBefore && hasAfter) {
+            result = Type.UPDATED;
+        } else if (hasAfter) {
+            result = Type.CREATED;
+        } else if (hasBefore) {
+            result = Type.REMOVED;
+        } else {
+            LOGGER.warning("Received push event with both \"before\" and \"after\" set to non-existing revision. Assuming removal.");
+            result = Type.REMOVED;
         }
-        if (!pushEvent.getCommits().get(0).getRemoved().isEmpty()) {
-            return Type.REMOVED;
-        }
-        return Type.UPDATED;
+        return result;
+    }
+
+    private static boolean isPresent(String ref) {
+        return !(ref.equals(NULL_REV));
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabTagPushSCMEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabTagPushSCMEvent.java
@@ -12,21 +12,11 @@ import org.eclipse.jgit.lib.Constants;
 import org.gitlab4j.api.webhook.TagPushEvent;
 
 import static jenkins.scm.api.SCMEvent.Type.CREATED;
-import static jenkins.scm.api.SCMEvent.Type.REMOVED;
 
 public class GitLabTagPushSCMEvent extends AbstractGitLabSCMHeadEvent<TagPushEvent> {
 
-    private static final String NONE_HASH_PATTERN = "^0+$";
-
     public GitLabTagPushSCMEvent(TagPushEvent tagPushEvent, String origin) {
         super(typeOf(tagPushEvent), tagPushEvent, origin);
-    }
-
-    private static Type typeOf(TagPushEvent tagPushEvent) {
-        if (tagPushEvent.getAfter().matches(NONE_HASH_PATTERN)) {
-            return REMOVED;
-        }
-        return Type.CREATED;
     }
 
     /**


### PR DESCRIPTION
When pushing a new branch to GitLab with same head as default branch I was getting IndexOutOfBoundsExceptions. Issue was caused by the implementation of the hook, which assumed that commits are always present. In this case `pushEvent.getCommits()` was returning empty list as seen in the webhook payload.

Also I thought that the `typeOf` method has been implemented incorrectly: it is seems to me incorrect to assume that branch is added when first (last?) commit has added lines, removed, when no added lines are present and removed lines are, and updated otherwise.

Attached anonymized log [gitlab-branches-plugin.log](https://github.com/jenkinsci/gitlab-branch-source-plugin/files/3584959/gitlab-branches-plugin.log) with the webhook payload and stacktrace.