### PR TITLE
Initialize transient fields after XStream deserialization

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -6,6 +6,7 @@ import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.Util;
@@ -918,4 +919,14 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         }
     }
 
+    @SuppressFBWarnings(value="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification="Known to be null during deserialization")
+    private Object readResolve() {
+        if (mergeRequestMetadataCache == null) {
+            mergeRequestMetadataCache = new ConcurrentHashMap<>();
+        }
+        if (mergeRequestContributorCache == null) {
+            mergeRequestContributorCache = new ConcurrentHashMap<>();
+        }
+        return this;
+    }
 }

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceDeserializationTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceDeserializationTest.java
@@ -1,0 +1,23 @@
+package io.jenkins.plugins.gitlabbranchsource;
+
+import com.thoughtworks.xstream.XStream;
+import java.lang.reflect.Field;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class GitLabSCMSourceDeserializationTest {
+
+    @Test
+    public void afterDeserializationWithXStreamTransientFieldsAreNotNull() throws Exception {
+        XStream xs = new XStream();
+        GitLabSCMSource source = (GitLabSCMSource) xs.fromXML(xs.toXML(new GitLabSCMSource("Test Server", "Test Owner", "test-path")));
+        Field mergeRequestContributorCache = source.getClass().getDeclaredField("mergeRequestContributorCache");
+        mergeRequestContributorCache.setAccessible(true);
+        Field mergeRequestMetadataCache = source.getClass().getDeclaredField("mergeRequestMetadataCache");
+        mergeRequestMetadataCache.setAccessible(true);
+        assertNotNull(mergeRequestMetadataCache.get(source));
+        assertNotNull(mergeRequestContributorCache.get(source));
+    }
+
+}


### PR DESCRIPTION
In PR #37, transient fields were added: https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/37/files#diff-4b6b8e14acc625f02500586c2a9a7e2aR119-R125. These fields should be initialized upon deserialization. To reproduce issue:

1. Setup multibranch job with GitLab branch provider with all hooks configured
1. Restart Jenkins
1. Open merge request in GitLab to trigger event

Attached a file with stacktrace: [npe-after-restart.log](https://github.com/jenkinsci/gitlab-branch-source-plugin/files/3585081/npe-after-restart.log)
 

