### PR TITLE
fix potential null pointer in lightweight checkout and support fetching Jenkinsfile from directory

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFile.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFile.java
@@ -20,6 +20,7 @@ public class GitLabSCMFile extends SCMFile {
     public GitLabSCMFile(GitLabApi gitLabApi, String projectPath, String ref) {
         super();
         this.gitLabApi = gitLabApi;
+        this.isDir = true;
         type(Type.DIRECTORY);
         this.projectPath = projectPath;
         this.ref = ref;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFile.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFile.java
@@ -9,7 +9,6 @@ import javassist.NotFoundException;
 import jenkins.scm.api.SCMFile;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
-import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.RepositoryFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,22 +17,22 @@ public class GitLabSCMFile extends SCMFile {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GitLabSCMFile.class);
     private final GitLabApi gitLabApi;
-    private final Project project;
+    private final String projectPath;
     private final String ref;
     private Boolean isFile;
 
-    public GitLabSCMFile(GitLabApi gitLabApi, Project project, String ref) {
+    public GitLabSCMFile(GitLabApi gitLabApi, String projectPath, String ref) {
         super();
         this.gitLabApi = gitLabApi;
         type(Type.DIRECTORY);
-        this.project = project;
+        this.projectPath = projectPath;
         this.ref = ref;
     }
 
     private GitLabSCMFile(@NonNull GitLabSCMFile parent, String name, Boolean isFile) {
         super(parent, name);
         this.gitLabApi = parent.gitLabApi;
-        this.project = parent.project;
+        this.projectPath = parent.projectPath;
         this.ref = parent.ref;
         this.isFile = isFile;
     }
@@ -75,7 +74,7 @@ public class GitLabSCMFile extends SCMFile {
     private Boolean checkFile() throws NotFoundException {
         RepositoryFile file = null;
         try {
-            file = gitLabApi.getRepositoryFileApi().getFileInfo(project, getPath(), ref);
+            file = gitLabApi.getRepositoryFileApi().getFileInfo(projectPath, getPath(), ref);
         } catch (GitLabApiException e) {
             throw new NotFoundException(
                 "No Jenkinsfile found in the root of the repository, skipping " + ref);
@@ -100,7 +99,7 @@ public class GitLabSCMFile extends SCMFile {
 
     private InputStream fetchFile() {
         try {
-            return gitLabApi.getRepositoryFileApi().getRawFile(project, ref, getPath());
+            return gitLabApi.getRepositoryFileApi().getRawFile(projectPath, ref, getPath());
         } catch (GitLabApiException e) {
             LOGGER.info("Jenkinsfile Not found: " + ref);
         }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFile.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFile.java
@@ -15,7 +15,7 @@ public class GitLabSCMFile extends SCMFile {
     private final GitLabApi gitLabApi;
     private final String projectPath;
     private final String ref;
-    private Boolean isDir;
+    private boolean isDir;
 
     public GitLabSCMFile(GitLabApi gitLabApi, String projectPath, String ref) {
         super();
@@ -26,7 +26,7 @@ public class GitLabSCMFile extends SCMFile {
         this.ref = ref;
     }
 
-    private GitLabSCMFile(@NonNull GitLabSCMFile parent, String name, Boolean isDir) {
+    private GitLabSCMFile(@NonNull GitLabSCMFile parent, String name, boolean isDir) {
         super(parent, name);
         this.gitLabApi = parent.gitLabApi;
         this.projectPath = parent.projectPath;
@@ -46,7 +46,7 @@ public class GitLabSCMFile extends SCMFile {
     @NonNull
     @Override
     protected SCMFile newChild(@NonNull String name, boolean assumeIsDirectory) {
-        return new GitLabSCMFile(this, name, assumeIsDirectory ? Boolean.TRUE : null);
+        return new GitLabSCMFile(this, name, assumeIsDirectory);
     }
 
     @NonNull

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFile.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFile.java
@@ -8,7 +8,6 @@ import java.util.List;
 import jenkins.scm.api.SCMFile;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
-import org.gitlab4j.api.models.RepositoryFile;
 import org.gitlab4j.api.models.TreeItem;
 
 public class GitLabSCMFile extends SCMFile {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
@@ -16,19 +16,24 @@ import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceDescriptor;
 import org.gitlab4j.api.GitLabApi;
-import org.gitlab4j.api.models.Project;
 
 public class GitLabSCMFileSystem extends SCMFileSystem {
 
     private final GitLabApi gitLabApi;
-    private final Project project;
+    private final String projectPath;
+    private final Date lastActivity;
     private final String ref;
 
-    protected GitLabSCMFileSystem(GitLabApi gitLabApi, Project project, String ref,
+    protected GitLabSCMFileSystem(
+        GitLabApi gitLabApi,
+        String projectPath,
+        Date lastActivity,
+        String ref,
         @CheckForNull SCMRevision rev) throws IOException {
         super(rev);
         this.gitLabApi = gitLabApi;
-        this.project = project;
+        this.projectPath = projectPath;
+        this.lastActivity = lastActivity;
         if (rev != null) {
             if (rev.getHead() instanceof MergeRequestSCMHead) {
                 this.ref = ((MergeRequestSCMRevision) rev).getOrigin().getHash();
@@ -46,7 +51,6 @@ public class GitLabSCMFileSystem extends SCMFileSystem {
 
     @Override
     public long lastModified() throws IOException {
-        Date lastActivity = project.getLastActivityAt();
         if (lastActivity == null) {
             return 0;
         }
@@ -56,7 +60,7 @@ public class GitLabSCMFileSystem extends SCMFileSystem {
     @NonNull
     @Override
     public SCMFile getRoot() {
-        return new GitLabSCMFile(gitLabApi, project, ref);
+        return new GitLabSCMFile(gitLabApi, projectPath, ref);
     }
 
     @Extension
@@ -90,7 +94,7 @@ public class GitLabSCMFileSystem extends SCMFileSystem {
         }
 
         public SCMFileSystem build(@NonNull SCMHead head, @CheckForNull SCMRevision rev,
-            @NonNull GitLabApi gitLabApi, @NonNull Project gitlabProject)
+            @NonNull GitLabApi gitLabApi, @NonNull String projectPath, Date lastActivity)
             throws IOException, InterruptedException {
             String ref;
             if (head instanceof MergeRequestSCMHead) {
@@ -102,7 +106,7 @@ public class GitLabSCMFileSystem extends SCMFileSystem {
             } else {
                 return null;
             }
-            return new GitLabSCMFileSystem(gitLabApi, gitlabProject, ref, rev);
+            return new GitLabSCMFileSystem(gitLabApi, projectPath, lastActivity, ref, rev);
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -701,7 +701,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             GitLabApi gitLabApi = apiBuilder(serverName);
             getGitlabProject(gitLabApi);
             LOGGER.info("Creating a probe: " + head.getName());
-            final SCMFileSystem fs = builder.build(head, revision, gitLabApi, gitlabProject);
+            final SCMFileSystem fs = builder.build(head, revision, gitLabApi, projectPath,
+                gitlabProject.getLastActivityAt());
             return new SCMProbe() {
                 @NonNull
                 @Override

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -701,8 +701,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             GitLabApi gitLabApi = apiBuilder(serverName);
             getGitlabProject(gitLabApi);
             LOGGER.info("Creating a probe: " + head.getName());
-            final SCMFileSystem fs = builder.build(head, revision, gitLabApi, projectPath,
-                gitlabProject.getLastActivityAt());
+            final SCMFileSystem fs = builder.build(head, revision, gitLabApi, projectPath);
             return new SCMProbe() {
                 @NonNull
                 @Override


### PR DESCRIPTION
As project can be nullable due to it's transient nature it is safer to use `projectPath`

I also updated `lastModified` to use the commit date for the `SCMFileSystem`