### PR TITLE
Fix target branch hash for merge requests

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMEvent.java
@@ -1,7 +1,6 @@
 package io.jenkins.plugins.gitlabbranchsource;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Locale;
@@ -14,9 +13,6 @@ import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
-import org.gitlab4j.api.GitLabApi;
-import org.gitlab4j.api.GitLabApiException;
-import org.gitlab4j.api.models.MergeRequest;
 import org.gitlab4j.api.webhook.MergeRequestEvent;
 
 public class GitLabMergeRequestSCMEvent extends AbstractGitLabSCMHeadEvent<MergeRequestEvent> {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMEvent.java
@@ -134,8 +134,6 @@ public class GitLabMergeRequestSCMEvent extends AbstractGitLabSCMHeadEvent<Merge
                 .equals(getPayload().getObjectAttributes().getTargetProjectId());
             String originOwner = getPayload().getUser().getUsername();
             String originProjectPath = m.getSource().getPathWithNamespace();
-            GitLabApi gitLabApi = GitLabHelper.apiBuilder(source.getServerName());
-            MergeRequest mr = gitLabApi.getMergeRequestApi().getMergeRequest(getPayload().getObjectAttributes().getSourceProjectId(), m.getIid());
             for (ChangeRequestCheckoutStrategy strategy : strategies.get(fork)) {
                 MergeRequestSCMHead h = new MergeRequestSCMHead(
                     "MR-" + m.getIid() + (strategies.size() > 1 ? "-" + strategy.name()
@@ -157,7 +155,7 @@ public class GitLabMergeRequestSCMEvent extends AbstractGitLabSCMHeadEvent<Merge
                         h,
                         new BranchSCMRevision(
                             h.getTarget(),
-                            mr.getDiffRefs().getStartSha()
+                            "HEAD"
                         ),
                         new BranchSCMRevision(
                             new BranchSCMHead(h.getOriginName()),
@@ -165,7 +163,7 @@ public class GitLabMergeRequestSCMEvent extends AbstractGitLabSCMHeadEvent<Merge
                         )
                     ));
             }
-        } catch (IOException | GitLabApiException e) {
+        } catch (IOException e) {
             e.printStackTrace();
         }
         return result;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -451,7 +451,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                                         head,
                                         new BranchSCMRevision(
                                             head.getTarget(),
-                                            m.getDiffRefs().getBaseSha()
+                                            m.getDiffRefs().getStartSha() // Latest revision of target branch
                                         ),
                                         new BranchSCMRevision(
                                             new BranchSCMHead(head.getOriginName()),

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -429,6 +429,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                         } else if (fork) {
                             originProjectPath = forkMrSources.get(m.getSourceProjectId());
                         }
+                        String targetSha = gitLabApi.getRepositoryApi().getBranch(m.getTargetProjectId(), m.getTargetBranch()).getCommit().getId();
                         LOGGER.info(originOwner + " -> " + (request.isMember(originOwner) ? "TRUE"
                             : "FALSE"));
                         for (ChangeRequestCheckoutStrategy strategy : strategies.get(fork)) {
@@ -451,7 +452,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                                         head,
                                         new BranchSCMRevision(
                                             head.getTarget(),
-                                            m.getDiffRefs().getStartSha() // Latest revision of target branch
+                                            targetSha // Latest revision of target branch
                                         ),
                                         new BranchSCMRevision(
                                             new BranchSCMHead(head.getOriginName()),

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -266,6 +266,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 MergeRequest mr =
                     gitLabApi.getMergeRequestApi()
                         .getMergeRequest(gitlabProject, Integer.parseInt(h.getId()));
+                String targetSha = gitLabApi.getRepositoryApi().getBranch(mr.getTargetProjectId(), mr.getTargetBranch()).getCommit().getId();
                 if (mr.getState().equals(Constants.MergeRequestState.OPENED.toString())) {
                     listener.getLogger().format("Current revision of merge request #%s is %s%n",
                         h.getId(), mr.getDiffRefs().getHeadSha());
@@ -273,11 +274,11 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                         h,
                         new BranchSCMRevision(
                             h.getTarget(),
-                            mr.getDiffRefs().getBaseSha()
+                            targetSha
                         ),
                         new BranchSCMRevision(
                             new BranchSCMHead(h.getOriginName()),
-                            mr.getDiffRefs().getHeadSha()
+                            mr.getSha()
                         )
                     );
                 } else {
@@ -390,11 +391,6 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     listener.getLogger().format("%nChecking merge requests..%n");
                     HashMap<Integer, String> forkMrSources = new HashMap<>();
                     for (MergeRequest mr : request.getMergeRequests()) {
-                        // Since by default GitLab4j do not populate DiffRefs for a list of Merge Requests
-                        // It is required to get the individual diffRef using the Iid.
-                        final MergeRequest m =
-                            gitLabApi.getMergeRequestApi()
-                                .getMergeRequest(gitlabProject, mr.getIid());
                         mergeRequestContributorCache.put(mr.getIid(),
                             new ContributorMetadataAction(
                                 mr.getAuthor().getUsername(),
@@ -411,41 +407,41 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                         listener.getLogger().format("%nChecking merge request %s%n",
                             HyperlinkNote.encodeTo(
                                 mergeRequestUriTemplate(gitlabProject.getWebUrl())
-                                    .set("iid", m.getIid())
+                                    .set("iid", mr.getIid())
                                     .expand(),
-                                "!" + m.getIid()
+                                "!" + mr.getIid()
                             )
                         );
                         Map<Boolean, Set<ChangeRequestCheckoutStrategy>> strategies = request
                             .getMRStrategies();
-                        boolean fork = !m.getSourceProjectId().equals(m.getTargetProjectId());
-                        String originOwner = m.getAuthor().getUsername();
+                        boolean fork = !mr.getSourceProjectId().equals(mr.getTargetProjectId());
+                        String originOwner = mr.getAuthor().getUsername();
                         String originProjectPath = projectPath;
-                        if (fork && !forkMrSources.containsKey(m.getSourceProjectId())) {
+                        if (fork && !forkMrSources.containsKey(mr.getSourceProjectId())) {
                             // This is a hack to get the path with namespace of source project for forked mrs
                             originProjectPath = gitLabApi.getProjectApi()
-                                .getProject(m.getSourceProjectId()).getPathWithNamespace();
-                            forkMrSources.put(m.getSourceProjectId(), originProjectPath);
+                                .getProject(mr.getSourceProjectId()).getPathWithNamespace();
+                            forkMrSources.put(mr.getSourceProjectId(), originProjectPath);
                         } else if (fork) {
-                            originProjectPath = forkMrSources.get(m.getSourceProjectId());
+                            originProjectPath = forkMrSources.get(mr.getSourceProjectId());
                         }
-                        String targetSha = gitLabApi.getRepositoryApi().getBranch(m.getTargetProjectId(), m.getTargetBranch()).getCommit().getId();
+                        String targetSha = gitLabApi.getRepositoryApi().getBranch(mr.getTargetProjectId(), mr.getTargetBranch()).getCommit().getId();
                         LOGGER.info(originOwner + " -> " + (request.isMember(originOwner) ? "TRUE"
                             : "FALSE"));
                         for (ChangeRequestCheckoutStrategy strategy : strategies.get(fork)) {
                             if (request.process(new MergeRequestSCMHead(
-                                    "MR-" + m.getIid() + (strategies.size() > 1 ? "-" + strategy.name()
+                                    "MR-" + mr.getIid() + (strategies.size() > 1 ? "-" + strategy.name()
                                         .toLowerCase(Locale.ENGLISH) : ""),
-                                    m.getIid(),
-                                    new BranchSCMHead(m.getTargetBranch()),
+                                    mr.getIid(),
+                                    new BranchSCMHead(mr.getTargetBranch()),
                                     ChangeRequestCheckoutStrategy.MERGE,
                                     fork
                                         ? new SCMHeadOrigin.Fork(originProjectPath)
                                         : SCMHeadOrigin.DEFAULT,
                                     originOwner,
                                     originProjectPath,
-                                    m.getSourceBranch(),
-                                    m.getTitle()
+                                    mr.getSourceBranch(),
+                                    mr.getTitle()
                                 ),
                                 (SCMSourceRequest.RevisionLambda<MergeRequestSCMHead, MergeRequestSCMRevision>) head ->
                                     new MergeRequestSCMRevision(
@@ -456,7 +452,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                                         ),
                                         new BranchSCMRevision(
                                             new BranchSCMHead(head.getOriginName()),
-                                            m.getDiffRefs().getHeadSha()
+                                            mr.getSha()
                                         )
                                     ),
                                 new SCMSourceRequest.ProbeLambda<MergeRequestSCMHead, MergeRequestSCMRevision>() {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/MergeRequestSCMRevision.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/MergeRequestSCMRevision.java
@@ -21,7 +21,7 @@ public class MergeRequestSCMRevision extends ChangeRequestSCMRevision<MergeReque
      * @param origin the {@link BranchSCMRevision} of the {@link MergeRequestSCMHead#getOrigin()}
      * head.
      */
-    protected MergeRequestSCMRevision(
+    public MergeRequestSCMRevision(
         @NonNull MergeRequestSCMHead head,
         @NonNull BranchSCMRevision target,
         @NonNull BranchSCMRevision origin) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/MergeWithGitSCMExtension.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/MergeWithGitSCMExtension.java
@@ -59,7 +59,7 @@ public class MergeWithGitSCMExtension extends GitSCMExtension {
                 baseObjectId = git.revParse(Constants.R_REFS + baseName);
             } catch (GitException e) {
                 listener.getLogger()
-                    .printf("Unable to determine head revision of %s prior to merge with PR%n",
+                    .printf("Unable to determine head revision of %s prior to merge with MR%n",
                         baseName);
                 throw e;
             }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/MergeWithGitSCMExtension.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/MergeWithGitSCMExtension.java
@@ -66,7 +66,7 @@ public class MergeWithGitSCMExtension extends GitSCMExtension {
         } else {
             baseObjectId = ObjectId.fromString(baseHash);
         }
-        listener.getLogger().printf("Merging %s commit %s into PR head commit %s%n",
+        listener.getLogger().printf("Merging %s commit %s into MR head commit %s%n",
             baseName, baseObjectId.name(), rev.getSha1String()
         );
         checkout(scm, build, git, listener, rev);

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabBrowser.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabBrowser.java
@@ -80,7 +80,7 @@ public class GitLabBrowser extends GitRepositoryBrowser {
     }
 
     @Extension
-    public static class DescriptorImp extends Descriptor<RepositoryBrowser<?>> {
+    public static class DescriptorImpl extends Descriptor<RepositoryBrowser<?>> {
 
         @NonNull
         public String getDisplayName() {


### PR DESCRIPTION
This is an attempt to fix the merge request revision (of type merge) to use the latest revision of target branch. Figured out that diffRef's `basesha` always returns the old revision when mr was created but `startsha` returns the latest revision of target branch. Although still does not fix the issues and merge requests still gets merged with the old commit of target branch. I am wondering what's causing this issue? :confused: 