### PR TITLE
Add the option in the GitLabServer param : host on own server

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -82,7 +82,7 @@ public class GitLabHookCreator {
             default:
                 return;
         }
-        String hookUrl = getHookUrl(true);
+        String hookUrl = getHookUrl(true, server.isHostedOnOwnServer());
         if (hookUrl.equals("")) {
             return;
         }
@@ -126,7 +126,7 @@ public class GitLabHookCreator {
 
     public static void createSystemHookWhenMissing(GitLabServer server,
         PersonalAccessToken credentials) {
-        String systemHookUrl = getHookUrl(false);
+        String systemHookUrl = getHookUrl(false, server.isHostedOnOwnServer());
         try {
             GitLabApi gitLabApi = new GitLabApi(server.getServerUrl(),
                 credentials.getToken().getPlainText());
@@ -145,13 +145,15 @@ public class GitLabHookCreator {
         }
     }
 
-    public static String getHookUrl(boolean isWebHook) {
+    public static String getHookUrl(boolean isWebHook, boolean hostedOnOwnServer) {
         JenkinsLocationConfiguration locationConfiguration = JenkinsLocationConfiguration.get();
         String rootUrl = locationConfiguration.getUrl();
         if (StringUtils.isBlank(rootUrl)) {
             return "";
         }
-        checkURL(rootUrl);
+        if (!hostedOnOwnServer) {
+            checkURL(rootUrl);
+        }
         String pronoun = "gitlab-systemhook";
         if (isWebHook) {
             pronoun = "gitlab-webhook";

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -70,6 +70,7 @@ import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCreden
 import static com.cloudbees.plugins.credentials.domains.URIRequirementBuilder.fromUri;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.apiBuilder;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getServerUrlFromName;
+import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getServerUrlOrDefault;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabIcons.ICON_GITLAB;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabIcons.iconFilePathPattern;
 
@@ -246,9 +247,10 @@ public class GitLabSCMNavigator extends SCMNavigator {
             GitLabApi webhookGitLabApi = null;
             String webHookUrl = null;
             if (webHookCredentials != null) {
-                webhookGitLabApi = new GitLabApi(getServerUrlFromName(serverName),
+                GitLabServer server = GitLabServers.get().findServer(serverName);
+                webhookGitLabApi = new GitLabApi(getServerUrlOrDefault(server),
                     webHookCredentials.getToken().getPlainText());
-                webHookUrl = GitLabHookCreator.getHookUrl(true);
+                webHookUrl = GitLabHookCreator.getHookUrl(true, server != null && server.isHostedOnOwnServer());
             }
             for (Project p : projects) {
                 count++;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
@@ -27,7 +27,7 @@ public class GitLabHelper {
     @NonNull
     public static String getServerUrlFromName(String serverName) {
         GitLabServer server = GitLabServers.get().findServer(serverName);
-        return server != null ? server.getServerUrl() : GitLabServer.GITLAB_SERVER_URL;
+        return getServerUrlOrDefault(server);
     }
 
     @NonNull
@@ -37,6 +37,11 @@ public class GitLabHelper {
         } else {
             return getServerUrlFromName(server);
         }
+    }
+
+    @NonNull
+    public static String getServerUrlOrDefault(GitLabServer server) {
+        return server != null ? server.getServerUrl() : GitLabServer.GITLAB_SERVER_URL;
     }
 
     public static UriTemplateBuilder getUriTemplateFromServer(String server) {

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -102,6 +102,12 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     @NonNull
     private String credentialsId;
 
+
+    /**
+     * {@code true} if GitLab is hosted on own server
+     */
+    private boolean hostedOnOwnServer;
+
     /**
      * Data Bound Constructor for only mandatory parameter serverUrl
      *
@@ -166,6 +172,29 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     public void setManageWebHooks(boolean manageWebHooks) {
         this.manageWebHooks = manageWebHooks;
     }
+
+
+    /**
+     * Returns {@code true} if Gitlab is hosted on own server
+     *
+     * @return {@code true} if Gitlab is hosted on own server
+     */
+
+    public boolean  isHostedOnOwnServer() {
+        return this.hostedOnOwnServer;
+    }
+
+    /**
+     * Data Bound Setter for Gitlab hosted on own server
+     *
+     * @param hostedOnOwnServer {@code true} if Gitlab is hosted on own server
+     *
+     */
+    @DataBoundSetter
+    public void setHostedOnOwnServer(boolean hostedOnOwnServer) {
+        this.hostedOnOwnServer = hostedOnOwnServer;
+    }
+
 
     /**
      * Returns {@code true} if Jenkins is supposed to auto-manage system hooks for this end-point.

--- a/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/config.groovy
+++ b/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/config.groovy
@@ -28,6 +28,10 @@ f.entry(title: _("System Hook"), field: "manageSystemHooks", "description": "Do 
     f.checkbox(title: _("Manage System Hooks"))
 }
 
+f.entry(title: _("Hosted On Own Server"), field: "hostedOnOwnServer", "description": "Do you host GitLab on your own server ?") {
+    f.checkbox(title: _("Hosted On Own Server"))
+}
+
 f.validateButton(
     title: _("Test connection"),
     progress: _("Testing.."),

--- a/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/help-hostedOnOwnServer.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/help-hostedOnOwnServer.html
@@ -1,0 +1,3 @@
+<div>
+  Selecting this option will allow the use of localhost prefix as Jenkins server url.
+</div>

--- a/src/test/java/io/jenkins/plugins/gitlabserverconfig/casc/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabserverconfig/casc/ConfigurationAsCodeTest.java
@@ -39,6 +39,7 @@ public class ConfigurationAsCodeTest {
         assertThat(server.getName(), matchesPattern("gitlab-[0-9]{4}"));
         assertThat(server.isManageWebHooks(), is(true));
         assertThat(server.isManageSystemHooks(), is(true));
+        assertThat(server.isHostedOnOwnServer(), is(true));
 
         List<PersonalAccessTokenImpl> credentials = CredentialsProvider.lookupCredentials(
             PersonalAccessTokenImpl.class, j.jenkins, ACL.SYSTEM,

--- a/src/test/resources/io/jenkins/plugins/gitlabserverconfig/casc/configuration-as-code.yml
+++ b/src/test/resources/io/jenkins/plugins/gitlabserverconfig/casc/configuration-as-code.yml
@@ -13,5 +13,6 @@ unclassified:
       - credentialsId: "i<3GitLab"
         manageSystemHooks: true
         manageWebHooks: true
+        hostedOnOwnServer : true
         name: gitlab-3213
         serverUrl: "https://gitlab.com"

--- a/src/test/resources/io/jenkins/plugins/gitlabserverconfig/casc/expected_output.yml
+++ b/src/test/resources/io/jenkins/plugins/gitlabserverconfig/casc/expected_output.yml
@@ -1,5 +1,6 @@
 servers:
 - credentialsId: "i<3GitLab"
+  hostedOnOwnServer: true
   manageSystemHooks: true
   manageWebHooks: true
   name: "gitlab-[0-9]{4}"


### PR DESCRIPTION
Based on https://issues.jenkins-ci.org/browse/JENKINS-59759?filter=-2, here is a PR with some changes allowing : 
- to keep the current URL check for projects relying on gitlab.com  
- to bypass the current URL check for projects relying on a GitLab installed on own server.

That is a small change but a little annoyed by the lack of unit-integration tests.