### PR TITLE
Fix build url in gitlab comment

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
@@ -122,7 +122,7 @@ public class GitLabPipelineStatusNotifier {
             symbol = ":no_entry_sign: ";
             note = "The Jenkins CI build aborted ";
         }
-        String suffix = " - [Details](" + url + "console)";
+        String suffix = " - [Details](" + url + ")";
         SCMRevision revision = SCMRevisionAction.getRevision(source, build);
         try {
             GitLabApi gitLabApi = GitLabHelper.apiBuilder(source.getServerName());


### PR DESCRIPTION
In our Jenkins v2.190.1 instance build url added in gitlab comment is:

    https://<jenkins host>/job/<gitlab group>/job/<gitlab project>/job/MR-345-merge/3/display/redirectconsole

This url is invalid. It shows 404 page.

Correct urls are:

    https://<jenkins host>/job/<gitlab group>/job/<gitlab project>/job/MR-345-merge/3/display/redirect

or

    https://<jenkins host>/job/<gitlab group>/job/<gitlab project>/job/MR-345-merge/3/display/redirect/console

Both urls redirects to build log in blue ocean.

In this PR I remove console part which will result in url:

    https://<jenkins host>/job/<gitlab group>/job/<gitlab project>/job/MR-345-merge/3/display/redirect