### PR TITLE
Fix for build which start from user without Administers permission.

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.gitlabserverconfig.servers;
 
 import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -206,7 +207,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
      */
     public PersonalAccessToken getCredentials() {
         Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(Jenkins.ADMINISTER);
+        jenkins.checkPermission(CredentialsProvider.USE_OWN);
         return StringUtils.isBlank(credentialsId) ? null : CredentialsMatchers.firstOrNull(
             lookupCredentials(
                 PersonalAccessToken.class,


### PR DESCRIPTION
When build start from user without Administers permission throw error:
```Branch indexing
Running as jenkins
hudson.security.AccessDeniedException2: jenkins is missing the Overall/Administer permission
	at hudson.security.ACL.checkPermission(ACL.java:73)
	at hudson.security.AccessControlled.checkPermission(AccessControlled.java:47)
	at io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer.getCredentials(GitLabServer.java:209)
	at io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.apiBuilder(GitLabHelper.java:17)
	at io.jenkins.plugins.gitlabbranchsource.GitLabSCMSource.retrieve(GitLabSCMSource.java:251)
	at jenkins.scm.api.SCMSource.fetch(SCMSource.java:582)
	at org.jenkinsci.plugins.workflow.multibranch.SCMBinder.create(SCMBinder.java:98)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:293)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
Finished: FAILURE
```

In this PR I change checking Jenkins.ADMINISTER to CredentialsProvider.USE_OWN.

CredentialsProvider.USE_OWN selected because of this is recommended by documentation: [Credentials/UseOwn](https://github.com/jenkinsci/credentials-plugin/blob/dc35d4d99f9d4e9bf5fd434aee4f6e1bfca4c47d/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java#L138)
