### PR TITLE
Fix a null pointer exception after #56

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -269,7 +269,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 String targetSha = gitLabApi.getRepositoryApi().getBranch(mr.getTargetProjectId(), mr.getTargetBranch()).getCommit().getId();
                 if (mr.getState().equals(Constants.MergeRequestState.OPENED.toString())) {
                     listener.getLogger().format("Current revision of merge request #%s is %s%n",
-                        h.getId(), mr.getDiffRefs().getHeadSha());
+                        h.getId(), mr.getSha());
                     return new MergeRequestSCMRevision(
                         h,
                         new BranchSCMRevision(


### PR DESCRIPTION
In https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/56/commits/bf4cf8727d774c3ee088e87b0fa13d1c7cb48c18#r353622448, one occurence of `mr.getDiffRefs().getHeadSha()` was not changed to `mr.getSha()` which can lead to a null pointer exception.