### PR TITLE
Respect the chosen ChangeRequestCheckoutStrategy

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMEvent.java
@@ -139,7 +139,7 @@ public class GitLabMergeRequestSCMEvent extends AbstractGitLabSCMHeadEvent<Merge
                         .toLowerCase(Locale.ENGLISH) : ""),
                     m.getIid(),
                     new BranchSCMHead(m.getTargetBranch()),
-                    ChangeRequestCheckoutStrategy.MERGE,
+                    strategy,
                     fork
                         ? new SCMHeadOrigin.Fork(originProjectPath)
                         : SCMHeadOrigin.DEFAULT,

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -434,7 +434,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                                         .toLowerCase(Locale.ENGLISH) : ""),
                                     mr.getIid(),
                                     new BranchSCMHead(mr.getTargetBranch()),
-                                    ChangeRequestCheckoutStrategy.MERGE,
+                                    strategy,
                                     fork
                                         ? new SCMHeadOrigin.Fork(originProjectPath)
                                         : SCMHeadOrigin.DEFAULT,


### PR DESCRIPTION
Use the chosen merge strategy when building MR instead of always merge.
Without this change, if you chose to build both merged and unmerged MR, the 2 builds will start with a merge with the target branch, which should only happen in the merged one.