### PR TITLE
Do not suffix MR name with merge strategy if only one is chosen

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMEvent.java
@@ -135,7 +135,7 @@ public class GitLabMergeRequestSCMEvent extends AbstractGitLabSCMHeadEvent<Merge
             String originProjectPath = m.getSource().getPathWithNamespace();
             for (ChangeRequestCheckoutStrategy strategy : strategies.get(fork)) {
                 MergeRequestSCMHead h = new MergeRequestSCMHead(
-                    "MR-" + m.getIid() + (strategies.size() > 1 ? "-" + strategy.name()
+                    "MR-" + m.getIid() + (strategies.get(fork).size() > 1 ? "-" + strategy.name()
                         .toLowerCase(Locale.ENGLISH) : ""),
                     m.getIid(),
                     new BranchSCMHead(m.getTargetBranch()),

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -430,7 +430,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                             : "FALSE"));
                         for (ChangeRequestCheckoutStrategy strategy : strategies.get(fork)) {
                             if (request.process(new MergeRequestSCMHead(
-                                    "MR-" + mr.getIid() + (strategies.size() > 1 ? "-" + strategy.name()
+                                    "MR-" + mr.getIid() + (strategies.get(fork).size() > 1 ? "-" + strategy.name()
                                         .toLowerCase(Locale.ENGLISH) : ""),
                                     mr.getIid(),
                                     new BranchSCMHead(mr.getTargetBranch()),


### PR DESCRIPTION
In https://github.com/jenkinsci/gitlab-branch-source-plugin/commit/44b8b5a8616365256b952a7bb6652250cddeeead#r36271968, the loop on `ChangeRequestCheckoutStrategy` has been modified, but the check for the number of them has not been updated, resulting in MR names being always suffixed with the strategy used (-head or -merge), even when there is only one chosen.
`strategies.size()` must be changed to actually be the size of the `Set<ChangeRequestCheckoutStrategy>`, and not the size of the `Map<Boolean, Set>` which will always be > 1.