### PR TITLE
ensure root URL ends with slash

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.gitlabbranchsource;
 
 import com.damnhandy.uri.template.UriTemplate;
+import com.damnhandy.uri.template.UriTemplateBuilder;
 import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
@@ -150,12 +151,13 @@ public class GitLabHookCreator {
             return "";
         }
         checkURL(rootUrl);
-        String pronoun = "gitlab-systemhook";
+        UriTemplateBuilder templateBuilder = UriTemplate.buildFromTemplate(rootUrl);
         if (isWebHook) {
-            pronoun = "gitlab-webhook";
+            templateBuilder.literal("gitlab-webhook");
+        } else {
+            templateBuilder.literal("gitlab-systemhook");
         }
-        return UriTemplate.buildFromTemplate(rootUrl).literal(pronoun).literal("/post").build()
-            .expand();
+        return templateBuilder.literal("/post").build().expand();
     }
 
     static void checkURL(String url) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -8,7 +8,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jenkins.model.JenkinsLocationConfiguration;
+import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMNavigatorOwner;
 import org.apache.commons.lang.StringUtils;
 import org.gitlab4j.api.GitLabApi;
@@ -145,15 +145,14 @@ public class GitLabHookCreator {
     }
 
     public static String getHookUrl(boolean isWebHook) {
-        JenkinsLocationConfiguration locationConfiguration = JenkinsLocationConfiguration.get();
-        String rootUrl = locationConfiguration.getUrl();
+        String rootUrl = Jenkins.get().getRootUrl();
         if (StringUtils.isBlank(rootUrl)) {
             return "";
         }
         checkURL(rootUrl);
-        String pronoun = "/gitlab-systemhook";
+        String pronoun = "gitlab-systemhook";
         if (isWebHook) {
-            pronoun = "/gitlab-webhook";
+            pronoun = "gitlab-webhook";
         }
         return UriTemplate.buildFromTemplate(rootUrl).literal(pronoun).literal("/post").build()
             .expand();

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreatorParameterizedTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreatorParameterizedTest.java
@@ -1,0 +1,55 @@
+package io.jenkins.plugins.gitlabbranchsource;
+
+import java.util.Arrays;
+import jenkins.model.JenkinsLocationConfiguration;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Parameterized.class)
+public class GitLabHookCreatorParameterizedTest {
+
+    @ClassRule
+    public static JenkinsRule r = new JenkinsRule();
+
+    private final String jenkinsUrl;
+    private final boolean hookType;
+    private final String expectedPath;
+
+    @Parameters(name = "check {0}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"intranet.local:8080", false, "/gitlab-systemhook/post"},
+            {"intranet.local", true, "/gitlab-webhook/post"},
+            {"www.mydomain.com:8000", true, "/gitlab-webhook/post"},
+            {"www.mydomain.com", false, "/gitlab-systemhook/post"}
+        });
+    }
+
+    public GitLabHookCreatorParameterizedTest(String jenkinsUrl, boolean hookType, String expectedPath) {
+        this.jenkinsUrl = jenkinsUrl;
+        this.hookType = hookType;
+        this.expectedPath = expectedPath;
+    }
+
+    @Test
+    public void hookUrl() {
+        Arrays.asList("http://", "https://").forEach(
+            proto -> {
+                String expected = proto + jenkinsUrl + expectedPath;
+                JenkinsLocationConfiguration.get().setUrl(proto + jenkinsUrl);
+                String hookUrl = GitLabHookCreator.getHookUrl(hookType);
+                GitLabHookCreator.checkURL(hookUrl);
+                assertThat(hookUrl.replaceAll(proto, ""), not(containsString("//")));
+                assertThat(hookUrl, is(expected));
+            });
+    }
+}


### PR DESCRIPTION
the `getRootUrl()` behaves differently, however it ensures that `JenkinsLocationConfiguration.get().getUrl()` ends with `/`
```java
    public String getRootUrl() throws IllegalStateException {
        JenkinsLocationConfiguration config = JenkinsLocationConfiguration.get();
        if (config == null) {
            Jenkins j = getInstance();
            throw new IllegalStateException("Jenkins instance " + j + " has been successfully initialized, but JenkinsLocationConfiguration is undefined.");
        } else {
            String url = config.getUrl();
            if (url != null) {
                return Util.ensureEndsWith(url, "/");
            } else {
                StaplerRequest req = Stapler.getCurrentRequest();
                return req != null ? this.getRootUrlFromRequest() : null;
            }
        }
    }
```