### PR TITLE
Remove trailing slash in rootUrl before setting up hook url

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.gitlabbranchsource;
 
 import com.damnhandy.uri.template.UriTemplate;
+import com.damnhandy.uri.template.UriTemplateBuilder;
 import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
@@ -151,12 +152,16 @@ public class GitLabHookCreator {
             return "";
         }
         checkURL(rootUrl);
-        String pronoun = "/gitlab-systemhook";
-        if (isWebHook) {
-            pronoun = "/gitlab-webhook";
+        if (rootUrl.endsWith("/")) {
+            rootUrl = rootUrl.substring(0, rootUrl.length() - 1);
         }
-        return UriTemplate.buildFromTemplate(rootUrl).literal(pronoun).literal("/post").build()
-            .expand();
+        UriTemplateBuilder uriBuilder = UriTemplate.buildFromTemplate(rootUrl);
+        if (isWebHook) {
+            uriBuilder = uriBuilder.literal("/gitlab-webhook");
+        } else {
+            uriBuilder = uriBuilder.literal("/gitlab-systemhook");
+        }
+        return uriBuilder.literal("/post").build().expand();
     }
 
     static void checkURL(String url) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -5,8 +5,6 @@ import com.damnhandy.uri.template.UriTemplateBuilder;
 import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.JenkinsLocationConfiguration;
@@ -151,7 +149,7 @@ public class GitLabHookCreator {
         if (StringUtils.isBlank(rootUrl)) {
             return "";
         }
-        checkURL(rootUrl);
+        UrlChecker.get().checkURL(rootUrl);
         if (rootUrl.endsWith("/")) {
             rootUrl = rootUrl.substring(0, rootUrl.length() - 1);
         }
@@ -163,24 +161,6 @@ public class GitLabHookCreator {
         }
         return uriBuilder.literal("/post").build().expand();
     }
-
-    static void checkURL(String url) {
-        try {
-            URL anURL = new URL(url);
-            if ("localhost".equals(anURL.getHost())) {
-                throw new IllegalStateException(
-                    "Jenkins URL cannot start with http://localhost \nURL is: " + url);
-            }
-            if (!anURL.getHost().contains(".")) {
-                throw new IllegalStateException(
-                    "You must use a fully qualified domain name for Jenkins URL, this is required by GitLab"
-                        + "\nURL is: " + url);
-            }
-        } catch (MalformedURLException e) {
-            throw new IllegalStateException("Bad Jenkins URL\nURL is: " + url);
-        }
-    }
-
 
     public static ProjectHook createWebHook() {
         ProjectHook enabledHooks = new ProjectHook();

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/UrlChecker.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/UrlChecker.java
@@ -1,0 +1,39 @@
+package io.jenkins.plugins.gitlabbranchsource;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class UrlChecker {
+
+    private static UrlChecker singleton;
+
+    UrlChecker() {
+
+    }
+
+    public static UrlChecker get() {
+        if (singleton == null) {
+            singleton = new UrlChecker();
+        }
+        return singleton;
+    }
+
+    URL checkURL(String url) {
+        try {
+            URL anURL = new URL(url);
+            if ("localhost".equals(anURL.getHost())) {
+                throw new IllegalStateException(
+                    "Jenkins URL cannot start with http://localhost \nURL is: " + url);
+            }
+            if (!anURL.getHost().contains(".")) {
+                throw new IllegalStateException(
+                    "You must use a fully qualified domain name for Jenkins URL, this is required by GitLab"
+                        + "\nURL is: " + url);
+            }
+            return anURL;
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException("Bad Jenkins URL\nURL is: " + url);
+        }
+    }
+
+}

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreatorTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreatorTest.java
@@ -1,0 +1,55 @@
+package io.jenkins.plugins.gitlabbranchsource;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.net.URL;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+
+public class GitLabHookCreatorTest {
+
+    class UrlCheckerMock extends UrlChecker {
+        public UrlCheckerMock() {}
+        @Override
+        URL checkURL(String url) { return new URL(url); }
+    }
+
+    private void mockUrlChecker() throws Exception {
+        Field urlChecker = UrlChecker.class.getDeclaredField("singleton");
+        urlChecker.setAccessible(true);
+        urlChecker.set(null, UrlCheckerMock.class.newInstance());
+    }
+
+    @Rule
+    public final RestartableJenkinsRule plan = new RestartableJenkinsRule();
+
+    @Test
+    public void shouldCreateWebHook() {
+        plan.then(j -> {
+            GitLabHookCreatorTest.this.mockUrlChecker();
+
+            URL rootUrl = j.getURL();
+            assertEquals(
+                rootUrl.getProtocol() + "://"+ rootUrl.getHost() +":"+ rootUrl.getPort() +"/jenkins/gitlab-webhook/post",
+                GitLabHookCreator.getHookUrl(true)
+            );
+        });
+    }
+
+    @Test
+    public void shouldCreateSystemHook() {
+        plan.then(j -> {
+            GitLabHookCreatorTest.this.mockUrlChecker();
+
+            URL rootUrl = j.getURL();
+            assertEquals(
+                rootUrl.getProtocol() + "://"+ rootUrl.getHost() +":"+ rootUrl.getPort() +"/jenkins/gitlab-systemhook/post",
+                GitLabHookCreator.getHookUrl(false)
+            );
+        });
+    }
+
+}


### PR DESCRIPTION
Removing trailing slash in root url before setting up hook url. This is intended to prevent double slash issue in generated hook url.


Refering to this comment https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/61#issuecomment-567415511

