### PR TITLE
[JENKINS-60915] - Add additional support for the SCM API 2.0 spec 

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
@@ -94,10 +94,12 @@ public class GitLabSCMFileSystem extends SCMFileSystem {
         
         @Override
         public SCMFileSystem build(@NonNull SCMSource source, @NonNull SCMHead head,
-           @CheckForNull SCMRevision rev){
-            GitLabApi gitLabApi = apiBuilder(source.getServerName());
-            String projectPath = source.getProjectPath();
-            return build(head, rev, gitlabApi, projectPath); 
+           @CheckForNull SCMRevision rev)
+           throws IOException, InterruptedException {
+            GitLabSCMSource gitlabScmSource = (GitLabSCMSource) source;
+            GitLabApi gitLabApi = apiBuilder(gitlabScmSource.getServerName());
+            String projectPath = gitlabScmSource.getProjectPath();
+            return build(head, rev, gitLabApi, projectPath); 
         }
 
         public SCMFileSystem build(@NonNull SCMHead head, @CheckForNull SCMRevision rev,

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
@@ -16,6 +16,8 @@ import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceDescriptor;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
+import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.apiBuilder;
+
 
 public class GitLabSCMFileSystem extends SCMFileSystem {
 
@@ -88,6 +90,14 @@ public class GitLabSCMFileSystem extends SCMFileSystem {
         public SCMFileSystem build(@NonNull Item owner, @NonNull SCM scm,
             @CheckForNull SCMRevision rev) {
             return null;
+        }
+        
+        @Override
+        public SCMFileSystem build(@NonNull SCMSource source, @NonNull SCMHead head,
+           @CheckForNull SCMRevision rev){
+            GitLabApi gitLabApi = apiBuilder(source.getServerName());
+            String projectPath = source.getProjectPath();
+            return build(head, rev, gitlabApi, projectPath); 
         }
 
         public SCMFileSystem build(@NonNull SCMHead head, @CheckForNull SCMRevision rev,

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
@@ -16,8 +16,8 @@ import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceDescriptor;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
-import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.apiBuilder;
 
+import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.apiBuilder;
 
 public class GitLabSCMFileSystem extends SCMFileSystem {
 
@@ -91,7 +91,7 @@ public class GitLabSCMFileSystem extends SCMFileSystem {
             @CheckForNull SCMRevision rev) {
             return null;
         }
-        
+
         @Override
         public SCMFileSystem build(@NonNull SCMSource source, @NonNull SCMHead head,
            @CheckForNull SCMRevision rev)
@@ -99,7 +99,7 @@ public class GitLabSCMFileSystem extends SCMFileSystem {
             GitLabSCMSource gitlabScmSource = (GitLabSCMSource) source;
             GitLabApi gitLabApi = apiBuilder(gitlabScmSource.getServerName());
             String projectPath = gitlabScmSource.getProjectPath();
-            return build(head, rev, gitLabApi, projectPath); 
+            return build(head, rev, gitLabApi, projectPath);
         }
 
         public SCMFileSystem build(@NonNull SCMHead head, @CheckForNull SCMRevision rev,


### PR DESCRIPTION
fixes [JENKINS-60915](https://issues.jenkins-ci.org/browse/JENKINS-60915)

This pull request enables the generation of an SCMFileSystem through the ``build(@NonNull SCMSource source, @NonNull SCMHead head, @CheckForNull SCMRevision rev)`` spec. 

This is done by using the SCMSource parameter to fetch the relevant ``GitLabApi`` object and ``projectPath`` to pass to the existing ``build()`` functionality. 

I have tested this works as expected.  