### PR TITLE
[JENKINS-61020] Add configurable commit status identifier

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/BuildStatusNameCustomPartTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/BuildStatusNameCustomPartTrait.java
@@ -1,0 +1,75 @@
+package io.jenkins.plugins.gitlabbranchsource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public class BuildStatusNameCustomPartTrait extends SCMSourceTrait {
+
+    @NonNull
+    private String buildStatusNameCustomPart = "";
+
+    /**
+     * Constructor for stapler.
+     */
+    @DataBoundConstructor
+    public BuildStatusNameCustomPartTrait() {
+        // empty
+    }
+
+    /**
+     * Setter for stapler to set the buildStatusNameCustomPart of the build status
+     */
+    @DataBoundSetter
+    public void setBuildStatusNameCustomPart(@NonNull String buildStatusNameCustomPart) {
+        this.buildStatusNameCustomPart = buildStatusNameCustomPart;
+    }
+
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        if (context instanceof GitLabSCMSourceContext) {
+            GitLabSCMSourceContext ctx = (GitLabSCMSourceContext) context;
+            ctx.withBuildStatusNameCustomPart(getBuildStatusNameCustomPart());
+        }
+    }
+
+    /**
+     * Getter method for the build status context prefix
+     *
+     * @return build status context prefix
+     */
+    @NonNull
+    public String getBuildStatusNameCustomPart() {
+        return buildStatusNameCustomPart;
+    }
+
+    /**
+     * Our descriptor.
+     */
+    @Extension
+    @Symbol("buildStatusNameCustomPart")
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return Messages.BuildStatusNameCustomPartTrait_displayName();
+        }
+
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return GitLabSCMSourceContext.class;
+        }
+
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return GitLabSCMSource.class;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceContext.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceContext.java
@@ -45,6 +45,8 @@ public class GitLabSCMSourceContext
 
     private boolean projectAvatarDisabled;
 
+    private String buildStatusNameCustomPart = "";
+
     public GitLabSCMSourceContext(@CheckForNull SCMSourceCriteria criteria,
         @NonNull SCMHeadObserver observer) {
         super(criteria, observer);
@@ -116,6 +118,10 @@ public class GitLabSCMSourceContext
 
     public final String getCommentBody() {
         return commentBody;
+    }
+
+    public final String getBuildStatusNameCustomPart() {
+        return buildStatusNameCustomPart;
     }
 
     @NonNull
@@ -205,6 +211,12 @@ public class GitLabSCMSourceContext
 
     public final GitLabSCMSourceContext withCommentBody(String commentBody) {
         this.commentBody = commentBody;
+        return this;
+    }
+
+    @NonNull
+    public final GitLabSCMSourceContext withBuildStatusNameCustomPart(final String buildStatusNameCustomPart) {
+        this.buildStatusNameCustomPart = Util.fixNull(buildStatusNameCustomPart);
         return this;
     }
 

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/BuildStatusNameCustomPartTrait/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/BuildStatusNameCustomPartTrait/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="${%Build status name custom part}" field="buildStatusNameCustomPart">
+    <f:textbox/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/BuildStatusNameCustomPartTrait/help-buildStatusContextPrefix.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/BuildStatusNameCustomPartTrait/help-buildStatusContextPrefix.html
@@ -1,0 +1,6 @@
+<div>
+  Enter a string to customize the status/context name for status updates published to GitLab.
+  For a branch build the default name would be 'jenkinsci/branch'. With the buildStatusNameCustomPart
+  'custom' the name would be 'jenkinsci/custom/branch'.
+  This allows to have multiple GitLab-Branch-Sources for the same GitLab-project configured.
+</div>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
@@ -4,6 +4,7 @@ BranchDiscoveryTrait.authorityDisplayName=Trust origin branches
 BranchDiscoveryTrait.displayName=Discover branches
 BranchDiscoveryTrait.excludeMRs=Only branches that are not also filed as MRs
 BranchDiscoveryTrait.onlyMRs=Only branches that are also filed as MRs
+BuildStatusNameCustomPartTrait.displayName=Customize GitLab build status name
 ForkMergeRequestDiscoveryTrait.displayName=Discover merge requests from forks
 ForkMergeRequestDiscoveryTrait.headAndMerge=Both the current merge request revision and the merge request merged with \
 the current target branch revision


### PR DESCRIPTION
Allows to have multiple multibranch-pipelines with a GitLab-Branch-Source posting to different contexts for commit statuses.