### PR TITLE
fix(MergeRequestCommentTrigger): job scan premature exit

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestCommentTrigger.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestCommentTrigger.java
@@ -51,7 +51,7 @@ public class GitLabMergeRequestCommentTrigger extends AbstractGitLabJobTrigger<N
                             null, SCMHeadObserver.none())
                             .withTraits(gitLabSCMSource.getTraits());
                         if (!sourceContext.mrCommentTriggerEnabled()) {
-                            return;
+                            continue;
                         }
                         if (gitLabSCMSource.getProjectId() == getPayload().getMergeRequest()
                             .getTargetProjectId() && isTrustedMember(gitLabSCMSource)) {


### PR DESCRIPTION
The current implementation stops scanning for jobs to trigger if it meets a job without configured "Trigger build on merge request comment".