### PR TITLE
Reduce webhook logging

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSystemHookListener.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSystemHookListener.java
@@ -20,7 +20,7 @@ public class GitLabSystemHookListener implements SystemHookListener {
 
     @Override
     public void onProjectEvent(ProjectSystemHookEvent projectSystemHookEvent) {
-        LOGGER.log(Level.INFO, projectSystemHookEvent.toString());
+        LOGGER.log(Level.FINE, projectSystemHookEvent.toString());
         // TODO: implement handling `project_transfer` and `project_renamed`
         switch (projectSystemHookEvent.getEventName()) {
             case ProjectSystemHookEvent.PROJECT_CREATE_EVENT:
@@ -37,6 +37,6 @@ public class GitLabSystemHookListener implements SystemHookListener {
 
     @Override
     public void onGroupEvent(GroupSystemHookEvent groupSystemHookEvent) {
-        LOGGER.log(Level.INFO, groupSystemHookEvent.toString());
+        LOGGER.log(Level.FINE, groupSystemHookEvent.toString());
     }
 }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebHookListener.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebHookListener.java
@@ -21,28 +21,28 @@ public class GitLabWebHookListener implements WebHookListener {
 
     @Override
     public void onNoteEvent(NoteEvent noteEvent) {
-        LOGGER.log(Level.INFO, noteEvent.toString());
+        LOGGER.log(Level.FINE, noteEvent.toString());
         GitLabMergeRequestCommentTrigger trigger = new GitLabMergeRequestCommentTrigger(noteEvent);
         AbstractGitLabJobTrigger.fireNow(trigger);
     }
 
     @Override
     public void onMergeRequestEvent(MergeRequestEvent mrEvent) {
-        LOGGER.log(Level.INFO, mrEvent.toString());
+        LOGGER.log(Level.FINE, mrEvent.toString());
         GitLabMergeRequestSCMEvent trigger = new GitLabMergeRequestSCMEvent(mrEvent, origin);
         SCMHeadEvent.fireNow(trigger);
     }
 
     @Override
     public void onPushEvent(PushEvent pushEvent) {
-        LOGGER.log(Level.INFO, pushEvent.toString());
+        LOGGER.log(Level.FINE, pushEvent.toString());
         GitLabPushSCMEvent trigger = new GitLabPushSCMEvent(pushEvent, origin);
         SCMHeadEvent.fireNow(trigger);
     }
 
     @Override
     public void onTagPushEvent(TagPushEvent tagPushEvent) {
-        LOGGER.log(Level.INFO, tagPushEvent.toString());
+        LOGGER.log(Level.FINE, tagPushEvent.toString());
         GitLabTagPushSCMEvent trigger = new GitLabTagPushSCMEvent(tagPushEvent, origin);
         SCMHeadEvent.fireNow(trigger);
     }


### PR DESCRIPTION
Logging the webhook payload every time is very noisy:
```
2020-03-02 12:24:26.831+0000 [id=281]   INFO    i.j.p.g.GitLabWebHookListener#onPushEvent: {
  "object_kind" : "push",
  "eventName" : "push",
  "after" : "xxx",
  "before" : "xxx",
  "ref" : "refs/heads/master",
  "checkoutSha" : "xxx",
  "userId" : 501,
  "userName" : "XXX",
  "userUsername" : "xxx",
  "userEmail" : "",
  "userAvatar" : null,
  "projectId" : 2217,
  "project" : {
    "id" : 2217,
    "name" : "xxx",
    "description" : "",
    "webUrl" : "https://xxx",
    "avatarUrl" : null,
    "gitSshUrl" : "git@xxx.git",
    "gitHttpUrl" : "https://xxx.git",
    "namespace" : "XXX",
    "visibilityLevel" : 0,
    "pathWithNamespace" : "xxx",
    "defaultBranch" : "master",
    "ciConfigPath" : null,
    "homepage" : "https://xxx",
    "url" : "git@xxx.git",
    "sshUrl" : "git@xxx.git",
    "httpUrl" : "https://xxx.git"
  },
  "repository" : {
    "name" : "xxx",
    "url" : "git@xxx.git",
    "description" : "",
    "homepage" : "https://xxx",
    "git_http_url" : "https://xxx.git",
    "git_ssh_url" : "git@xxx.git",
    "visibility_level" : 0
  },
  "commits" : [ {
    "id" : "xxx",
    "message" : "XXX\n",
    "timestamp" : "2020-03-02T12:24:23Z",
    "url" : "https://xxx/commit/xxx",
    "author" : {
      "avatarUrl" : null,
      "createdAt" : null,
      "email" : "xxx",
      "id" : null,
      "name" : "Xxx",
      "state" : null,
      "username" : null,
      "webUrl" : null
    },
    "added" : [ "xxx.html" ],
    "modified" : [ "xxx.java" ],
    "removed" : [ ]
  } ],
  "totalCommitsCount" : 1,
  "objectKind" : "push"
}
```
I'd suggest to reduce the logging of the webhook listeners. You can still collect them using the Jenkins system log configuration, but it won't be logged by default.