### PR TITLE
[JENKINS-61320, JENKINS-59753] Remove transient modifier for ssh and http remote in scmsource

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -110,8 +110,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     private String projectName;
     private String credentialsId;
     private List<SCMSourceTrait> traits = new ArrayList<>();
-    private transient String sshRemote;
-    private transient String httpRemote;
+    private String sshRemote;
+    private String httpRemote;
     private transient Project gitlabProject;
     private int projectId = -1;
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -201,6 +201,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         if (gitlabProject == null) {
             try {
                 gitlabProject = gitLabApi.getProjectApi().getProject(projectPath);
+                sshRemote = gitlabProject.getSshUrlToRepo();
+                httpRemote = gitlabProject.getHttpUrlToRepo();
             } catch (GitLabApiException e) {
                 throw new IllegalStateException("Failed to retrieve project " + projectPath, e);
             }


### PR DESCRIPTION
sshRemote and httpRemote fields were unnecessarily set transient which caused configuration to be null after restart. Thanks to @Opa- for this finding this bug.