### PR TITLE
Fetch project id in SCMSource constructor

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -113,7 +113,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     private String sshRemote;
     private String httpRemote;
     private transient Project gitlabProject;
-    private String projectId;
+    private int projectId;
 
     /**
      * The cache of {@link ObjectMetadataAction} instances for each open MR.
@@ -203,6 +203,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 gitlabProject = gitLabApi.getProjectApi().getProject(projectPath);
                 sshRemote = gitlabProject.getSshUrlToRepo();
                 httpRemote = gitlabProject.getHttpUrlToRepo();
+                projectId = gitlabProject.getId();
             } catch (GitLabApiException e) {
                 throw new IllegalStateException("Failed to retrieve project " + projectPath, e);
             }
@@ -226,11 +227,11 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     }
 
     public int getProjectId() {
-        return Integer.parseInt(projectId);
+        return projectId;
     }
 
     @DataBoundSetter
-    public void setProjectId(String projectId) {
+    public void setProjectId(int projectId) {
         this.projectId = projectId;
     }
 
@@ -304,7 +305,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         try {
             GitLabApi gitLabApi = apiBuilder(serverName);
             getGitlabProject(gitLabApi);
-            setProjectId(gitlabProject.getId().toString());
+            setProjectId(gitlabProject.getId());
             sshRemote = gitlabProject.getSshUrlToRepo();
             httpRemote = gitlabProject.getHttpUrlToRepo();
             try (GitLabSCMSourceRequest request = new GitLabSCMSourceContext(criteria, observer)
@@ -792,10 +793,10 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             return result;
         }
 
-        public String getProjectId(@QueryParameter String projectPath, @QueryParameter String serverName) {
+        public int getProjectId(@QueryParameter String projectPath, @QueryParameter String serverName) {
             List<GitLabServer> gitLabServers = GitLabServers.get().getServers();
             if (gitLabServers.size() == 0) {
-                return "-1";
+                return -1;
             }
             try {
                 GitLabApi gitLabApi;
@@ -805,12 +806,12 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     gitLabApi = apiBuilder(serverName);
                 }
                 if (!projectPath.equals("")) {
-                    return gitLabApi.getProjectApi().getProject(projectPath).getId().toString();
+                    return gitLabApi.getProjectApi().getProject(projectPath).getId();
                 }
             } catch (GitLabApiException e) {
-                return "-1";
+                return -1;
             }
-            return "-1";
+            return -1;
         }
 
         public ListBoxModel doFillProjectPathItems(@AncestorInPath SCMSourceOwner context,

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -113,7 +113,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     private String sshRemote;
     private String httpRemote;
     private transient Project gitlabProject;
-    private int projectId = -1;
+    private int projectId;
 
     /**
      * The cache of {@link ObjectMetadataAction} instances for each open MR.
@@ -131,6 +131,11 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         this.serverName = serverName;
         this.projectOwner = projectOwner;
         this.projectPath = projectPath;
+        try {
+            this.projectId = apiBuilder(serverName).getProjectApi().getProject(projectPath).getId();
+        } catch (GitLabApiException e) {
+            LOGGER.log(Level.WARNING, "Failed to set project id");
+        }
     }
 
     public String getServerName() {
@@ -229,7 +234,6 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         return projectId;
     }
 
-    @DataBoundSetter
     public void setProjectId(int projectId) {
         this.projectId = projectId;
     }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -800,12 +800,12 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             }
             try {
                 GitLabApi gitLabApi;
-                if (serverName.equals("")) {
+                if (StringUtils.isBlank(serverName)) {
                     gitLabApi = apiBuilder(gitLabServers.get(0).getName());
                 } else {
                     gitLabApi = apiBuilder(serverName);
                 }
-                if (!projectPath.equals("")) {
+                if (StringUtils.isNotBlank(projectPath)) {
                     return gitLabApi.getProjectApi().getProject(projectPath).getId();
                 }
             } catch (GitLabApiException e) {

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
@@ -17,7 +17,7 @@
     <scm:traits field="traits"/>
   </f:entry>
   <f:invisibleEntry>
-    <f:textbox clazz="project-id" field="projectId"/>
+    <f:number clazz="project-id" field="projectId"/>
   </f:invisibleEntry>
   <script>
     // var projectOwner = document.getElementsByClassName('project-owner');

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
@@ -16,6 +16,9 @@
   <f:entry title="${%Behaviours}">
     <scm:traits field="traits"/>
   </f:entry>
+  <f:invisibleEntry field="projectId">
+    <f:textbox clazz="project-id number"/>
+  </f:invisibleEntry>
   <script>
     // var projectOwner = document.getElementsByClassName('project-owner');
     //

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
@@ -16,8 +16,8 @@
   <f:entry title="${%Behaviours}">
     <scm:traits field="traits"/>
   </f:entry>
-  <f:invisibleEntry field="projectId">
-    <f:textbox clazz="project-id number"/>
+  <f:invisibleEntry>
+    <f:textbox clazz="project-id" field="projectId"/>
   </f:invisibleEntry>
   <script>
     // var projectOwner = document.getElementsByClassName('project-owner');


### PR DESCRIPTION
Some user is facing this issue 
<img width="1010" alt="Screenshot 2020-04-10 at 5 22 09 AM" src="https://user-images.githubusercontent.com/23079344/78950100-4d3d7d00-7aeb-11ea-93bf-c840ccddf961.png">
Somehow the projectId is not set after job config is saved again. But when job config save retriggers a scan which sets the project id. Still yet if there is some way it is not set, I tried to set the project id in the DataBoundConstructor by calling the GitLab API but I feel this is wrong. 

Attempt 2:
Used an invisible entry that stores projectId based on projectPath. 
