### PR TITLE
enable configuration of an alternative Jenkins root URL for hooks

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -146,7 +146,7 @@ public class GitLabHookCreator {
     }
 
     /**
-     * @deprecated use {@link getHookUrl(String,boolean)} instead
+     * @deprecated use {@link #getHookUrl(String,boolean)} instead
      */
     @Deprecated
     public static String getHookUrl(boolean isWebHook) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -83,7 +83,7 @@ public class GitLabHookCreator {
             default:
                 return;
         }
-        String hookUrl = getHookUrl(server.getHooksRootUrl(), true);
+        String hookUrl = getHookUrl(server, true);
         if (hookUrl.equals("")) {
             return;
         }
@@ -127,7 +127,7 @@ public class GitLabHookCreator {
 
     public static void createSystemHookWhenMissing(GitLabServer server,
         PersonalAccessToken credentials) {
-        String systemHookUrl = getHookUrl(server.getHooksRootUrl(), false);
+        String systemHookUrl = getHookUrl(server, false);
         try {
             GitLabApi gitLabApi = new GitLabApi(server.getServerUrl(),
                 credentials.getToken().getPlainText());
@@ -146,7 +146,7 @@ public class GitLabHookCreator {
     }
 
     /**
-     * @deprecated use {@link #getHookUrl(String,boolean)} instead
+     * @deprecated use {@link #getHookUrl(GitLabServer,boolean)} instead
      */
     @Deprecated
     public static String getHookUrl(boolean isWebHook) {
@@ -154,13 +154,16 @@ public class GitLabHookCreator {
     }
 
     /**
-     * @param hooksRootUrl the root URL to use in the hook URL.
-     *        If {@code null} or empty, {@link Jenkins#getRootUrl()} will be used instead.
+     * @param server the {@code GitLabServer} for which the hooks URL would be created. If not {@code null} and it
+     *        has a {@link GitLabServer#getHooksRootUrl()}, then the hook URL will be based on this root URL.
+     *        Otherwise, the hook URL will be based on {@link Jenkins#getRootUrl()}.
      * @param isWebHook {@code true} to get the webhook URL, {@code false} for the systemhook URL
      * @return a webhook or systemhook URL
      */
-    public static String getHookUrl(String hooksRootUrl, boolean isWebHook) {
-        String rootUrl = (hooksRootUrl == null) ? Jenkins.get().getRootUrl() : hooksRootUrl;
+    public static String getHookUrl(GitLabServer server, boolean isWebHook) {
+        String rootUrl = (server == null || server.getHooksRootUrl() == null)
+                ? Jenkins.get().getRootUrl()
+                : server.getHooksRootUrl();
         if (StringUtils.isBlank(rootUrl)) {
             return "";
         }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -160,16 +160,16 @@ public class GitLabHookCreator {
      * @return a webhook or systemhook URL
      */
     public static String getHookUrl(String hooksRootUrl, boolean isWebHook) {
-        String rootUrl = StringUtils.isBlank(hooksRootUrl) ? Jenkins.get().getRootUrl() : hooksRootUrl;
+        String rootUrl = (hooksRootUrl == null) ? Jenkins.get().getRootUrl() : hooksRootUrl;
         if (StringUtils.isBlank(rootUrl)) {
             return "";
         }
         checkURL(rootUrl);
-        UriTemplateBuilder templateBuilder = UriTemplate.buildFromTemplate(StringUtils.stripEnd(rootUrl, "/"));
+        UriTemplateBuilder templateBuilder = UriTemplate.buildFromTemplate(rootUrl);
         if (isWebHook) {
-            templateBuilder.literal("/gitlab-webhook");
+            templateBuilder.literal("gitlab-webhook");
         } else {
-            templateBuilder.literal("/gitlab-systemhook");
+            templateBuilder.literal("gitlab-systemhook");
         }
         return templateBuilder.literal("/post").build().expand();
     }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -69,6 +69,8 @@ import org.kohsuke.stapler.QueryParameter;
 import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
 import static com.cloudbees.plugins.credentials.domains.URIRequirementBuilder.fromUri;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.apiBuilder;
+import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getHooksRootUrl;
+import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getServerUrl;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getServerUrlFromName;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabIcons.ICON_GITLAB;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabIcons.iconFilePathPattern;
@@ -245,9 +247,10 @@ public class GitLabSCMNavigator extends SCMNavigator {
             GitLabApi webhookGitLabApi = null;
             String webHookUrl = null;
             if (webHookCredentials != null) {
-                webhookGitLabApi = new GitLabApi(getServerUrlFromName(serverName),
+                GitLabServer server = GitLabServers.get().findServer(serverName);
+                webhookGitLabApi = new GitLabApi(getServerUrl(server),
                     webHookCredentials.getToken().getPlainText());
-                webHookUrl = GitLabHookCreator.getHookUrl(true);
+                webHookUrl = GitLabHookCreator.getHookUrl(getHooksRootUrl(server), true);
             }
             for (Project p : projects) {
                 count++;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -69,7 +69,6 @@ import org.kohsuke.stapler.QueryParameter;
 import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
 import static com.cloudbees.plugins.credentials.domains.URIRequirementBuilder.fromUri;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.apiBuilder;
-import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getHooksRootUrl;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getServerUrl;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getServerUrlFromName;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabIcons.ICON_GITLAB;
@@ -250,7 +249,7 @@ public class GitLabSCMNavigator extends SCMNavigator {
                 GitLabServer server = GitLabServers.get().findServer(serverName);
                 webhookGitLabApi = new GitLabApi(getServerUrl(server),
                     webHookCredentials.getToken().getPlainText());
-                webHookUrl = GitLabHookCreator.getHookUrl(getHooksRootUrl(server), true);
+                webHookUrl = GitLabHookCreator.getHookUrl(server, true);
             }
             for (Project p : projects) {
                 count++;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
@@ -3,6 +3,8 @@ package io.jenkins.plugins.gitlabbranchsource.helpers;
 import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.UriTemplateBuilder;
 import com.damnhandy.uri.template.impl.Operator;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
@@ -27,6 +29,11 @@ public class GitLabHelper {
     @NonNull
     public static String getServerUrlFromName(String serverName) {
         GitLabServer server = GitLabServers.get().findServer(serverName);
+        return getServerUrl(server);
+    }
+
+    @NonNull
+    public static String getServerUrl(GitLabServer server) {
         return server != null ? server.getServerUrl() : GitLabServer.GITLAB_SERVER_URL;
     }
 
@@ -37,6 +44,10 @@ public class GitLabHelper {
         } else {
             return getServerUrlFromName(server);
         }
+    }
+
+    public static String getHooksRootUrl(GitLabServer server) {
+        return server != null ? server.getHooksRootUrl() : null;
     }
 
     public static UriTemplateBuilder getUriTemplateFromServer(String server) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
@@ -3,8 +3,6 @@ package io.jenkins.plugins.gitlabbranchsource.helpers;
 import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.UriTemplateBuilder;
 import com.damnhandy.uri.template.impl.Operator;
-
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
@@ -44,10 +44,6 @@ public class GitLabHelper {
         }
     }
 
-    public static String getHooksRootUrl(GitLabServer server) {
-        return server != null ? server.getHooksRootUrl() : null;
-    }
-
     public static UriTemplateBuilder getUriTemplateFromServer(String server) {
         return UriTemplate.buildFromTemplate(getServerUrl(server));
     }

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -5,7 +5,6 @@ import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
-
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -236,11 +236,11 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
 
     /**
      * @return the custom root URL, to be used in hooks instead of {@link Jenkins#getRootUrl()}.
-     * Can be {@code null}.
+     * Can be either a root URL with its trailing slash, or {@code null}.
      */
     @CheckForNull
     public String getHooksRootUrl() {
-        return hooksRootUrl;
+        return Util.ensureEndsWith(Util.fixEmptyAndTrim(hooksRootUrl), "/");
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -226,7 +226,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     }
 
     /**
-     * @param hooksBaseUrl a custom root URL, to be used in hooks instead of {@link Jenkins#getRootUrl()}.
+     * @param hooksRootUrl a custom root URL, to be used in hooks instead of {@link Jenkins#getRootUrl()}.
      * Set to {@code null} for default behavior.
      */
     @DataBoundSetter

--- a/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/config.groovy
+++ b/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/config.groovy
@@ -28,6 +28,10 @@ f.entry(title: _("System Hook"), field: "manageSystemHooks", "description": "Do 
     f.checkbox(title: _("Manage System Hooks"))
 }
 
+f.entry(title: _("Root URL for hooks"), field: "hooksRootUrl", "description": "Jenkins root URL to use in hooks URL (if different from the public Jenkins root URL)") {
+    f.textbox()
+}
+
 f.validateButton(
     title: _("Test connection"),
     progress: _("Testing.."),

--- a/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/help-hooksRootUrl.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/help-hooksRootUrl.html
@@ -1,0 +1,4 @@
+<div>
+  The Jenkins root URL (for instance <code>https://something:8443/jenkins/</code>) to use in hooks URL.<br>
+  This is only required when the globally configured public URL for Jenkins can not be reached from your GitLab server.
+</div>

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreatorParameterizedTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreatorParameterizedTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.gitlabbranchsource;
 
+import hudson.Util;
 import java.util.Arrays;
 import jenkins.model.JenkinsLocationConfiguration;
 import org.junit.ClassRule;
@@ -8,8 +9,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import hudson.Util;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreatorParameterizedTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreatorParameterizedTest.java
@@ -1,6 +1,6 @@
 package io.jenkins.plugins.gitlabbranchsource;
 
-import hudson.Util;
+import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import java.util.Arrays;
 import jenkins.model.JenkinsLocationConfiguration;
 import org.junit.ClassRule;
@@ -61,8 +61,9 @@ public class GitLabHookCreatorParameterizedTest {
             proto -> {
                 String expected = proto + jenkinsUrl + expectedPath;
                 JenkinsLocationConfiguration.get().setUrl("http://whatever");
-                // GitlabServer#getHooksRootUrl() ensures a trailing slash, we do the same here
-                String hookUrl = GitLabHookCreator.getHookUrl(Util.ensureEndsWith(proto + jenkinsUrl, "/"), hookType);
+                GitLabServer server = new GitLabServer("https://gitlab.com", "GitLab", null);
+                server.setHooksRootUrl(proto + jenkinsUrl);
+                String hookUrl = GitLabHookCreator.getHookUrl(server, hookType);
                 GitLabHookCreator.checkURL(hookUrl);
                 assertThat(hookUrl.replaceAll(proto, ""), not(containsString("//")));
                 assertThat(hookUrl, is(expected));

--- a/src/test/java/io/jenkins/plugins/gitlabserverconfig/casc/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabserverconfig/casc/ConfigurationAsCodeTest.java
@@ -39,6 +39,7 @@ public class ConfigurationAsCodeTest {
         assertThat(server.getName(), matchesPattern("gitlab-[0-9]{4}"));
         assertThat(server.isManageWebHooks(), is(true));
         assertThat(server.isManageSystemHooks(), is(true));
+        assertThat(server.getHooksRootUrl(), is("https://jenkins.intranet/"));
 
         List<PersonalAccessTokenImpl> credentials = CredentialsProvider.lookupCredentials(
             PersonalAccessTokenImpl.class, j.jenkins, ACL.SYSTEM,

--- a/src/test/resources/io/jenkins/plugins/gitlabserverconfig/casc/configuration-as-code.yml
+++ b/src/test/resources/io/jenkins/plugins/gitlabserverconfig/casc/configuration-as-code.yml
@@ -11,6 +11,7 @@ unclassified:
   gitLabServers:
     servers:
       - credentialsId: "i<3GitLab"
+        hooksRootUrl: "https://jenkins.intranet/"
         manageSystemHooks: true
         manageWebHooks: true
         name: gitlab-3213

--- a/src/test/resources/io/jenkins/plugins/gitlabserverconfig/casc/expected_output.yml
+++ b/src/test/resources/io/jenkins/plugins/gitlabserverconfig/casc/expected_output.yml
@@ -1,5 +1,6 @@
 servers:
 - credentialsId: "i<3GitLab"
+  hooksRootUrl: "https://jenkins.intranet/"
   manageSystemHooks: true
   manageWebHooks: true
   name: "gitlab-[0-9]{4}"


### PR DESCRIPTION
In my company, because of a "complicated" network architecture, the main root URLs of our Jenkins servers (`Jenkins#getRootUrl()`) can not be reached from the Gitlab server. So the webhooks that `gitlab-branch-source-plugin` would create automatically can't work.

This PR adds a new config option to `GitlabServer`, an alternative root URL to use in the {system,web} hooks URLs generated by the plugin. It is of course optional, `Jenkins#getRootUrl()` is still used when this option is left blank.