### PR TITLE
[JENKINS-60304] Forward GitLabApiException as IOException

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
@@ -53,7 +53,7 @@ public class GitLabSCMFileSystem extends SCMFileSystem {
         try {
             return gitLabApi.getCommitsApi().getCommit(projectPath, ref).getCommittedDate().getTime();
         } catch (GitLabApiException e) {
-            return 0;
+            throw new IOException("Failed to retrieve last modified time", e);
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -302,6 +302,7 @@ public class GitLabSCMNavigator extends SCMNavigator {
             observer.getListener().getLogger().format("%n%d projects were processed%n", count);
         } catch (GitLabApiException e) {
             LOGGER.log(Level.WARNING, "Exception caught:" + e, e);
+            throw new IOException("Failed to visit SCM source", e);
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -294,8 +294,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             }
         } catch (GitLabApiException e) {
             LOGGER.log(Level.WARNING, "Exception caught:" + e, e);
+            throw new IOException("Failed to retrieve the SCM revision for " + head.getName(), e);
         }
-        return super.retrieve(head, listener);
     }
 
     @Override
@@ -528,6 +528,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             }
         } catch (GitLabApiException e) {
             LOGGER.log(Level.WARNING, "Exception caught:" + e, e);
+            throw new IOException("Failed to fetch latest heads", e);
         } finally {
             SCMSourceOwner owner = this.getOwner();
             if (owner != null) {


### PR DESCRIPTION
Forward GitLabApiException as IOException to inform SCM API about failures in eg retrieve methods. Otherwise unreachable/failed gitlab server calls are interpreted as 'empty' repositories, therfore all branches gets removed.