### PR TITLE
Feature/override trusted

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,8 @@ These traits can be selected by selecting `Add` in the `Behaviours` section.
 
 * `Log build status as comment on GitLab` - Enable logging build status as comment on GitLab. A comment is logged on the commit or merge request once the build is completed. You can decide if you want to log success builds or not. You can also use sudo user to comment the build status as commment e.g. `jenkinsadmin` or something similar. 
 
-* `Trigger build on merge request comment` - Enable trigger a rebuild of a merge request by comment with your desired comment body (default: `jenkins rebuild`). The job can only be triggered by trusted members of the project i.e. users with Developer/Maintainer/Owner accesslevel.
+* `Trigger build on merge request comment` - Enable trigger a rebuild of a merge request by comment with your desired comment body (default: `jenkins rebuild`). The job can only be triggered by trusted members of the project i.e. users with Developer/Maintainer/Owner accesslevel (also includes inherited from ancestor groups). By default only trusted members of project can trigger MR.
+You may want to disable this option because trusted members do not include members inherited from shared group (there is no way to get it from GitLabApi as of GitLab 13.0.0). If disabled, MR comment trigger can be done by any user having access to your project.
 
 * `Disable GitLab project avatar` - Disable avatars of GitLab project(s). It is not possible to fetch avatars when API has no token authentication or project is private. So you may use this option as a workaround. We will fix this issue in a later release.
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestCommentTrigger.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestCommentTrigger.java
@@ -54,7 +54,7 @@ public class GitLabMergeRequestCommentTrigger extends AbstractGitLabJobTrigger<N
                             continue;
                         }
                         if (gitLabSCMSource.getProjectId() == getPayload().getMergeRequest()
-                            .getTargetProjectId() && isTrustedMember(gitLabSCMSource)) {
+                            .getTargetProjectId() && isTrustedMember(gitLabSCMSource, sourceContext.onlyTrustedMembersCanTrigger())) {
                             for (Job<?, ?> job : owner.getAllJobs()) {
                                 if (mergeRequestJobNamePattern.matcher(job.getName()).matches()) {
                                     String expectedCommentBody = sourceContext.getCommentBody();
@@ -96,7 +96,11 @@ public class GitLabMergeRequestCommentTrigger extends AbstractGitLabJobTrigger<N
         }
     }
 
-    private boolean isTrustedMember(GitLabSCMSource gitLabSCMSource) {
+    private boolean isTrustedMember(GitLabSCMSource gitLabSCMSource, boolean check) {
+        // Return true if only trusted members can trigger option is not checked
+        if(!check) {
+            return true;
+        }
         AccessLevel permission = gitLabSCMSource.getMembers()
             .get(getPayload().getUser().getUsername());
         if (permission != null) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceContext.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceContext.java
@@ -41,6 +41,8 @@ public class GitLabSCMSourceContext
 
     private boolean mrCommentTriggerEnabled;
 
+    private boolean onlyTrustedMembersCanTrigger;
+
     private String commentBody = "";
 
     private boolean projectAvatarDisabled;
@@ -115,6 +117,8 @@ public class GitLabSCMSourceContext
     public final boolean mrCommentTriggerEnabled() {
         return mrCommentTriggerEnabled;
     }
+
+    public final boolean onlyTrustedMembersCanTrigger() { return onlyTrustedMembersCanTrigger; }
 
     public final String getCommentBody() {
         return commentBody;
@@ -194,6 +198,11 @@ public class GitLabSCMSourceContext
 
     public final GitLabSCMSourceContext withMRCommentTriggerEnabled(boolean enabled) {
         this.mrCommentTriggerEnabled = enabled;
+        return this;
+    }
+
+    public final GitLabSCMSourceContext withOnlyTrustedMembersCanTrigger(boolean enabled) {
+        this.onlyTrustedMembersCanTrigger = enabled;
         return this;
     }
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/TriggerMRCommentTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/TriggerMRCommentTrait.java
@@ -20,13 +20,20 @@ public class TriggerMRCommentTrait extends SCMSourceTrait {
     private final String commentBody;
 
     /**
+     * Only comment trigger by trusted members only (members having access to project)
+     */
+    private final boolean onlyTrustedMembers;
+
+    /**
      * Constructor.
      *
      * @param commentBody the comment body to trigger a new build on
+     * @param onlyTrustedMembers
      */
     @DataBoundConstructor
-    public TriggerMRCommentTrait(String commentBody) {
+    public TriggerMRCommentTrait(String commentBody, boolean onlyTrustedMembers) {
         this.commentBody = commentBody;
+        this.onlyTrustedMembers = onlyTrustedMembers;
     }
 
     /**
@@ -48,6 +55,7 @@ public class TriggerMRCommentTrait extends SCMSourceTrait {
     protected void decorateContext(SCMSourceContext<?, ?> context) {
         GitLabSCMSourceContext ctx = (GitLabSCMSourceContext) context;
         ctx.withMRCommentTriggerEnabled(true);
+        ctx.withOnlyTrustedMembersCanTrigger(onlyTrustedMembers);
         ctx.withCommentBody(getCommentBody());
     }
 

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/TriggerMRCommentTrait/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/TriggerMRCommentTrait/config.jelly
@@ -3,4 +3,7 @@
   <f:entry title="${%Comment Body}" field="commentBody">
     <f:textbox default="jenkins rebuild"/>
   </f:entry>
+  <f:entry title="${%Enable triggers by Trusted Members only}" field="onlyTrustedMembers">
+      <f:checkbox default="true"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/TriggerMRCommentTrait/help-commentBody.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/TriggerMRCommentTrait/help-commentBody.html
@@ -1,0 +1,3 @@
+<div>
+  Add comment body you want to use to instruct Jenkins CI to rebuild the MR
+</div>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/TriggerMRCommentTrait/help-onlyTrustedMembers.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/TriggerMRCommentTrait/help-onlyTrustedMembers.html
@@ -1,0 +1,5 @@
+<div>
+  If checked only trusted members of project can trigger MR. Trusted members mean members with Developer/Maintainer access (also includes inherited from ancestor groups) in the project.
+  You may want to disable this option because trusted members do not include members inherited from shared group (there is no way to get it from GitLabApi as of GitLab 13.0.0).
+  If disabled, MR comment trigger can be done by any user having access to your project.
+</div>


### PR DESCRIPTION
Based on discussions in gitter chat that `getAllMembers()` does not return shared group members