### PR TITLE
[JENKINS-62883] Add @Symbol to SCMSource and SCMNavigation descriptors

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -60,6 +60,7 @@ import org.gitlab4j.api.models.GroupProjectsFilter;
 import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.ProjectFilter;
 import org.jenkins.ui.icon.IconSpec;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -413,6 +414,7 @@ public class GitLabSCMNavigator extends SCMNavigator {
         );
     }
 
+    @Symbol("gitlab")
     @Extension
     public static class DescriptorImpl extends SCMNavigatorDescriptor implements IconSpec {
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -84,6 +84,7 @@ import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.ProjectFilter;
 import org.gitlab4j.api.models.Tag;
 import org.jenkins.ui.icon.IconSpec;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -726,6 +727,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 GitLabServer.CREDENTIALS_MATCHER);
     }
 
+    @Symbol("gitlab")
     @Extension
     public static class DescriptorImpl extends SCMSourceDescriptor implements IconSpec {
 


### PR DESCRIPTION
[JENKINS-62883](https://issues.jenkins-ci.org/browse/JENKINS-62883) Adding `@Symbol` to SCMSource and SCMNavigator descriptors.

@baymac 