### PR TITLE
Support setting build status when MR is from another project

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
@@ -41,6 +41,7 @@ import org.gitlab4j.api.Constants;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
 import org.gitlab4j.api.models.CommitStatus;
+import org.gitlab4j.api.models.MergeRequest;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 
 /**
@@ -193,6 +194,31 @@ public class GitLabPipelineStatusNotifier {
     }
 
     /**
+     * Retrieves the source project ID for a merge request
+     */
+    private static Integer getSourceProjectId(Job job, GitLabApi gitLabApi, String projectPath) {
+        LOGGER.log(Level.INFO, "Getting source project ID from MR");
+        String[] jobFullNameParts = job.getFullName().split("-");
+        Integer mrId = Integer.parseInt(jobFullNameParts[jobFullNameParts.length - 1]);
+        MergeRequest mr;
+        try {
+          mr = gitLabApi.getMergeRequestApi().getMergeRequest(
+              projectPath,
+              mrId
+          );
+        } catch (GitLabApiException e) {
+            if(!e.getMessage().contains(("Cannot transition status"))) {
+                LOGGER.log(Level.WARNING, String.format("Exception caught: %s",e.getMessage()));
+            }
+            return null;
+        }
+        Integer sourceProjectId = mr.getSourceProjectId();
+        LOGGER.log(Level.INFO, "Got source project ID from MR: {0}", String.valueOf(sourceProjectId));
+
+        return sourceProjectId;
+    }
+
+    /**
      * Sends notifications to GitLab on Checkout (for the "In Progress" Status).
      */
     private static void sendNotifications(Run<?, ?> build, TaskListener listener) {
@@ -276,11 +302,22 @@ public class GitLabPipelineStatusNotifier {
         try {
             GitLabApi gitLabApi = GitLabHelper.apiBuilder(source.getServerName());
             LOGGER.log(Level.FINE, String.format("Notifiying commit: %s", hash));
-            gitLabApi.getCommitsApi().addCommitStatus(
-                source.getProjectPath(),
-                hash,
-                state,
-                status);
+
+            if (revision instanceof MergeRequestSCMRevision) {
+                Integer projectId = getSourceProjectId(build.getParent(), gitLabApi, source.getProjectPath());
+                gitLabApi.getCommitsApi().addCommitStatus(
+                    projectId,
+                    hash,
+                    state,
+                    status);
+            } else {
+                gitLabApi.getCommitsApi().addCommitStatus(
+                    source.getProjectPath(),
+                    hash,
+                    state,
+                    status);
+            }
+
             listener.getLogger().format("[GitLab Pipeline Status] Notified%n");
         } catch (GitLabApiException e) {
             if(!e.getMessage().contains(("Cannot transition status"))) {
@@ -373,11 +410,22 @@ public class GitLabPipelineStatusNotifier {
                             // it is our nonce, so remove it
                             resolving.remove(job);
                         }
-                        gitLabApi.getCommitsApi().addCommitStatus(
-                            source.getProjectPath(),
-                            hash,
-                            state,
-                            status);
+
+                        if (revision instanceof MergeRequestSCMRevision) {
+                            Integer projectId = getSourceProjectId(job, gitLabApi, source.getProjectPath());
+                            gitLabApi.getCommitsApi().addCommitStatus(
+                                projectId,
+                                hash,
+                                state,
+                                status);
+                        } else {
+                            gitLabApi.getCommitsApi().addCommitStatus(
+                                source.getProjectPath(),
+                                hash,
+                                state,
+                                status);
+                        }
+
                         LOGGER.log(Level.INFO, "{0} Notified", job.getFullName());
                     } catch (GitLabApiException e) {
                         if(!e.getMessage().contains("Cannot transition status")) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
@@ -305,6 +305,7 @@ public class GitLabPipelineStatusNotifier {
 
             if (revision instanceof MergeRequestSCMRevision) {
                 Integer projectId = getSourceProjectId(build.getParent(), gitLabApi, source.getProjectPath());
+                status.setRef(((MergeRequestSCMRevision) revision).getOrigin().getHead().getName());
                 gitLabApi.getCommitsApi().addCommitStatus(
                     projectId,
                     hash,
@@ -395,6 +396,7 @@ public class GitLabPipelineStatusNotifier {
                     status.setTargetUrl(url);
                     status.setDescription(job.getFullName() + ": Build queued...");
                     status.setStatus("PENDING");
+
                     Constants.CommitBuildState state = Constants.CommitBuildState.PENDING;
                     try {
                         GitLabApi gitLabApi = GitLabHelper.apiBuilder(source.getServerName());
@@ -413,6 +415,7 @@ public class GitLabPipelineStatusNotifier {
 
                         if (revision instanceof MergeRequestSCMRevision) {
                             Integer projectId = getSourceProjectId(job, gitLabApi, source.getProjectPath());
+                            status.setRef(((MergeRequestSCMRevision) revision).getOrigin().getHead().getName());
                             gitLabApi.getCommitsApi().addCommitStatus(
                                 projectId,
                                 hash,


### PR DESCRIPTION
Currently if you have a fork in another project and try to do an MR into the main project, the API will return a 404 because it is looking for the commit in the wrong project. See https://github.com/jenkinsci/gitlab-plugin/issues/549 for similar problem discussion.

The change here is that now it will use the Gitlab API to find the source project ID instead of assuming it is the same. Also fixes a bug where the ref isn't sent as part of the status check, which caused status checks to not update for the correct MR when there is an MR and a branch with the same head sha.

This has fixed it for me.

Not a java dev, but hopefully this isn't too bad.