### PR TITLE
Bugfix JENKINS-63001 fix failing mr with deleted target branch

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -84,6 +84,7 @@ import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.ProjectFilter;
 import org.gitlab4j.api.models.Tag;
 import org.jenkins.ui.icon.IconSpec;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -731,7 +732,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 Jenkins.getAuthentication(), fromUri(getServerUrlFromName(serverName)).build()),
                 GitLabServer.CREDENTIALS_MATCHER);
     }
-
+    @Symbol("gitlab")
     @Extension
     public static class DescriptorImpl extends SCMSourceDescriptor implements IconSpec {
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -423,7 +423,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                         try {
                             targetSha = gitLabApi.getRepositoryApi().getBranch(mr.getTargetProjectId(), mr.getTargetBranch()).getCommit().getId();
                         } catch (Exception e) {
-                            LOGGER.log(Level.WARNING, "Failed getting Branch from Merge Request:" + e, e);
+                            listener.getLogger().format("Failed getting TargetBranch from Merge Request: " + mr.getIid() + " (" + mr.getTitle() + ")%n%s", e);
                             continue;
                         }
                         LOGGER.log(Level.FINE, String.format("%s -> %s", originOwner, (request.isMember(originOwner) ? "Trusted"

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -84,7 +84,6 @@ import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.ProjectFilter;
 import org.gitlab4j.api.models.Tag;
 import org.jenkins.ui.icon.IconSpec;
-import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -419,7 +419,13 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                         } else if (fork) {
                             originProjectPath = forkMrSources.get(mr.getSourceProjectId());
                         }
-                        String targetSha = gitLabApi.getRepositoryApi().getBranch(mr.getTargetProjectId(), mr.getTargetBranch()).getCommit().getId();
+                        String targetSha;
+                        try {
+                            targetSha = gitLabApi.getRepositoryApi().getBranch(mr.getTargetProjectId(), mr.getTargetBranch()).getCommit().getId();
+                        } catch (Exception e) {
+                            LOGGER.log(Level.WARNING, "Failed getting Branch from Merge Request:" + e, e);
+                            continue;
+                        }
                         LOGGER.log(Level.FINE, String.format("%s -> %s", originOwner, (request.isMember(originOwner) ? "Trusted"
                             : "Untrusted")));
                         for (ChangeRequestCheckoutStrategy strategy : strategies.get(fork)) {
@@ -727,7 +733,6 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 GitLabServer.CREDENTIALS_MATCHER);
     }
 
-    @Symbol("gitlab")
     @Extension
     public static class DescriptorImpl extends SCMSourceDescriptor implements IconSpec {
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -732,6 +732,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 Jenkins.getAuthentication(), fromUri(getServerUrlFromName(serverName)).build()),
                 GitLabServer.CREDENTIALS_MATCHER);
     }
+
     @Symbol("gitlab")
     @Extension
     public static class DescriptorImpl extends SCMSourceDescriptor implements IconSpec {


### PR DESCRIPTION
This Pull Request solves https://issues.jenkins.io/browse/JENKINS-63001.

A deleted target branch of a merge request in gitlab leads to a crash of scanning the branches.
Now the broken merge request is just skipped and an error is logged.