### PR TITLE
[JENKINS-64461] Don't create webhooks when webhooks aren't managed.

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -714,11 +714,14 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
 
     @Override
     public void afterSave() {
-        GitLabSCMSourceContext ctx = new GitLabSCMSourceContext(null, SCMHeadObserver.none())
+        GitLabServer server = GitLabServers.get().findServer(getServerName());
+        if (server.isManageWebHooks()) {
+            GitLabSCMSourceContext ctx = new GitLabSCMSourceContext(null, SCMHeadObserver.none())
                 .withTraits(new GitLabSCMNavigatorContext().withTraits(traits).traits());
-        GitLabHookRegistration webhookMode = ctx.webhookRegistration();
-        GitLabHookRegistration systemhookMode = ctx.systemhookRegistration();
-        GitLabHookCreator.register(this, webhookMode, systemhookMode);
+            GitLabHookRegistration webhookMode = ctx.webhookRegistration();
+            GitLabHookRegistration systemhookMode = ctx.systemhookRegistration();
+            GitLabHookCreator.register(this, webhookMode, systemhookMode);
+        }
     }
 
     public PersonalAccessToken credentials() {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -715,6 +715,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     @Override
     public void afterSave() {
         GitLabServer server = GitLabServers.get().findServer(getServerName());
+        // Only register webhooks in the case webhooks wants to be managed in
+        // the jenkins instance.
         if (server != null && server.isManageWebHooks()) {
             GitLabSCMSourceContext ctx = new GitLabSCMSourceContext(null, SCMHeadObserver.none())
                 .withTraits(new GitLabSCMNavigatorContext().withTraits(traits).traits());

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -715,7 +715,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     @Override
     public void afterSave() {
         GitLabServer server = GitLabServers.get().findServer(getServerName());
-        if (server.isManageWebHooks()) {
+        if (server != null && server.isManageWebHooks()) {
             GitLabSCMSourceContext ctx = new GitLabSCMSourceContext(null, SCMHeadObserver.none())
                 .withTraits(new GitLabSCMNavigatorContext().withTraits(traits).traits());
             GitLabHookRegistration webhookMode = ctx.webhookRegistration();


### PR DESCRIPTION
Solves https://issues.jenkins.io/browse/JENKINS-64461