### PR TITLE
Fix MR trigger by comment (#120)

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestCommentTrigger.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestCommentTrigger.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.gitlabbranchsource;
 
+import com.cloudbees.hudson.plugins.folder.computed.ComputedFolder;
 import hudson.model.CauseAction;
 import hudson.model.Job;
 import hudson.security.ACL;
@@ -38,8 +39,8 @@ public class GitLabMergeRequestCommentTrigger extends AbstractGitLabJobTrigger<N
                 boolean jobFound = false;
                 for (final SCMSourceOwner owner : SCMSourceOwners.all()) {
                     LOGGER.log(Level.FINEST, String.format("Source Owner: %s", owner.getFullDisplayName()));
-                    // This is a hack to skip owners which are children of a SCMNavigator
-                    if (owner.getFullDisplayName().contains(" » ")) {
+                    // It's better to check instance of parent instead of searching for » symbol
+                    if (owner.getParent() instanceof ComputedFolder) {
                         continue;
                     }
                     for (SCMSource source : owner.getSCMSources()) {


### PR DESCRIPTION
Fixes #120

This PR is an improvement of [previous hack](https://github.com/jenkinsci/gitlab-branch-source-plugin/commit/2bb3f613abd09f5bbc2406898eb719f9a35b6d45).

This hack is based on comparison of SCMSourceOwner parent with a string containing " » " substring.
Such approach caused bugs like [here](https://issues.jenkins.io/browse/JENKINS-60062).

Please, provide some feedback.