### PR TITLE
Feat/add corporate proxy support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <revision>1.5.5</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.176.4</jenkins.version>
+    <jenkins.version>2.263.4</jenkins.version>
     <java.level>8</java.level>
     <jcasc.version>1.36</jcasc.version>
   </properties>

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -17,6 +17,8 @@ import org.gitlab4j.api.GitLabApiException;
 import org.gitlab4j.api.models.ProjectHook;
 import org.gitlab4j.api.models.SystemHook;
 
+import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getProxyConfig;
+
 public class GitLabHookCreator {
 
     public static final Logger LOGGER = Logger.getLogger(GitLabHookCreator.class.getName());
@@ -91,7 +93,7 @@ public class GitLabHookCreator {
         if (credentials != null) {
             try {
                 GitLabApi gitLabApi = new GitLabApi(server.getServerUrl(),
-                    credentials.getToken().getPlainText());
+                    credentials.getToken().getPlainText(), null, getProxyConfig());
                 createWebHookWhenMissing(gitLabApi, source.getProjectPath(), hookUrl, secretToken);
             } catch (GitLabApiException e) {
                 LOGGER.log(Level.WARNING,
@@ -131,7 +133,7 @@ public class GitLabHookCreator {
         String systemHookUrl = getHookUrl(server, false);
         try {
             GitLabApi gitLabApi = new GitLabApi(server.getServerUrl(),
-                credentials.getToken().getPlainText());
+                credentials.getToken().getPlainText(), null, getProxyConfig());
             SystemHook systemHook = gitLabApi.getSystemHooksApi()
                 .getSystemHookStream()
                 .filter(hook -> systemHookUrl.equals(hook.getUrl()))

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -70,6 +70,7 @@ import org.kohsuke.stapler.QueryParameter;
 import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
 import static com.cloudbees.plugins.credentials.domains.URIRequirementBuilder.fromUri;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.apiBuilder;
+import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getProxyConfig;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getServerUrl;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getServerUrlFromName;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabIcons.ICON_GITLAB;
@@ -249,7 +250,7 @@ public class GitLabSCMNavigator extends SCMNavigator {
             if (webHookCredentials != null) {
                 GitLabServer server = GitLabServers.get().findServer(serverName);
                 webhookGitLabApi = new GitLabApi(getServerUrl(server),
-                    webHookCredentials.getToken().getPlainText());
+                    webHookCredentials.getToken().getPlainText(), null, getProxyConfig());
                 webHookUrl = GitLabHookCreator.getHookUrl(server, true);
             }
             for (Project p : projects) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
@@ -3,11 +3,15 @@ package io.jenkins.plugins.gitlabbranchsource.helpers;
 import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.UriTemplateBuilder;
 import com.damnhandy.uri.template.impl.Operator;
+import hudson.ProxyConfiguration;
 import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
+import java.util.Map;
+import jenkins.model.Jenkins;
 import org.eclipse.jgit.annotations.NonNull;
 import org.gitlab4j.api.GitLabApi;
+import org.gitlab4j.api.ProxyClientConfig;
 
 public class GitLabHelper {
 
@@ -16,12 +20,27 @@ public class GitLabHelper {
         if (server != null) {
             PersonalAccessToken credentials = server.getCredentials();
             if (credentials != null) {
-                return new GitLabApi(server.getServerUrl(), credentials.getToken().getPlainText());
+                return new GitLabApi(server.getServerUrl(), credentials.getToken().getPlainText(), null, getProxyConfig());
             }
-            return new GitLabApi(server.getServerUrl(), GitLabServer.EMPTY_TOKEN);
+            return new GitLabApi(server.getServerUrl(), GitLabServer.EMPTY_TOKEN, null, getProxyConfig());
         }
         throw new IllegalStateException(
             String.format("No server found with the name: %s", serverName));
+    }
+
+    public static Map<String, Object> getProxyConfig () {
+        ProxyConfiguration proxyConfiguration = Jenkins.get().getProxy();
+        if (proxyConfiguration != null) {
+            if (proxyConfiguration.getUserName() != null && proxyConfiguration.getSecretPassword() != null) {
+                return ProxyClientConfig.createProxyClientConfig(
+                    "http://" + proxyConfiguration.getName() + ":" + proxyConfiguration.getPort(),
+                    proxyConfiguration.getUserName(),
+                    proxyConfiguration.getSecretPassword().getPlainText());
+            }
+            return ProxyClientConfig.createProxyClientConfig(
+                "http://" + proxyConfiguration.getName() + ":" + proxyConfiguration.getPort());
+        }
+        return null;
     }
 
     @NonNull

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -39,6 +39,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.withId;
 import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
 import static com.cloudbees.plugins.credentials.domains.URIRequirementBuilder.fromUri;
+import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getProxyConfig;
 import static org.apache.commons.lang.StringUtils.defaultIfBlank;
 
 /**
@@ -308,7 +309,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
             if (GITLAB_SERVER_URL.equals(serverUrl)) {
                 LOGGER.log(Level.FINEST, String.format("Community version of GitLab: %s", serverUrl));
             }
-            GitLabApi gitLabApi = new GitLabApi(serverUrl, "");
+            GitLabApi gitLabApi = new GitLabApi(serverUrl, "", null, getProxyConfig());
             try {
                 gitLabApi.getProjectApi().getProjects(1, 1);
                 return FormValidation.ok();
@@ -360,7 +361,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
                 privateToken = credentials.getToken().getPlainText();
             }
             if (privateToken.equals(EMPTY_TOKEN)) {
-                GitLabApi gitLabApi = new GitLabApi(serverUrl, EMPTY_TOKEN);
+                GitLabApi gitLabApi = new GitLabApi(serverUrl, EMPTY_TOKEN, null, getProxyConfig());
                 try {
                     /*
                     In order to validate a GitLab Server without personal access token,
@@ -378,7 +379,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
                 }
             } else {
 
-                GitLabApi gitLabApi = new GitLabApi(serverUrl, privateToken);
+                GitLabApi gitLabApi = new GitLabApi(serverUrl, privateToken, null, getProxyConfig());
                 try {
                     User user = gitLabApi.getUserApi().getCurrentUser();
                     LOGGER.log(Level.FINEST, String


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

I propose this PR in response of the following issue : https://issues.jenkins.io/browse/JENKINS-62779

The point is to support corporate proxy. Before calling GitlabApi, we retrieve proxy parameters from Plugin Manager configuration.

My code is based on [gitlab4j-api proxy implementation](https://github.com/gitlab4j/gitlab4j-api#connecting-through-a-proxy-server).

Unfortunately, ProxyClientConfig does not support no_proxy parameter. At least, there is few chance to have multiple gitlab servers behind proxy and directly reachable.

About test : I didn't add any... but no tests have been broken. I did test the configuration on my Jenkins with this new version :
- Without proxy
- With unauthenticated corporate proxy

I do not have any environment to test with authenticated proxy.

Finally, feel free to propose any improvments, I'm kind of new here :)