### PR TITLE
[JENKINS-62779] handle proxy hosts exclusions

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -93,7 +93,7 @@ public class GitLabHookCreator {
         if (credentials != null) {
             try {
                 GitLabApi gitLabApi = new GitLabApi(server.getServerUrl(),
-                    credentials.getToken().getPlainText(), null, getProxyConfig());
+                    credentials.getToken().getPlainText(), null, getProxyConfig(server.getServerUrl()));
                 createWebHookWhenMissing(gitLabApi, source.getProjectPath(), hookUrl, secretToken);
             } catch (GitLabApiException e) {
                 LOGGER.log(Level.WARNING,
@@ -133,7 +133,7 @@ public class GitLabHookCreator {
         String systemHookUrl = getHookUrl(server, false);
         try {
             GitLabApi gitLabApi = new GitLabApi(server.getServerUrl(),
-                credentials.getToken().getPlainText(), null, getProxyConfig());
+                credentials.getToken().getPlainText(), null, getProxyConfig(server.getServerUrl()));
             SystemHook systemHook = gitLabApi.getSystemHooksApi()
                 .getSystemHookStream()
                 .filter(hook -> systemHookUrl.equals(hook.getUrl()))

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -249,8 +249,9 @@ public class GitLabSCMNavigator extends SCMNavigator {
             String webHookUrl = null;
             if (webHookCredentials != null) {
                 GitLabServer server = GitLabServers.get().findServer(serverName);
-                webhookGitLabApi = new GitLabApi(getServerUrl(server),
-                    webHookCredentials.getToken().getPlainText(), null, getProxyConfig());
+                String serverUrl = getServerUrl(server);
+                webhookGitLabApi = new GitLabApi(serverUrl,
+                        webHookCredentials.getToken().getPlainText(), null, getProxyConfig(serverUrl));
                 webHookUrl = GitLabHookCreator.getHookUrl(server, true);
             }
             for (Project p : projects) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
@@ -7,7 +7,11 @@ import hudson.ProxyConfiguration;
 import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import jenkins.model.Jenkins;
 import org.eclipse.jgit.annotations.NonNull;
 import org.gitlab4j.api.GitLabApi;
@@ -19,18 +23,35 @@ public class GitLabHelper {
         GitLabServer server = GitLabServers.get().findServer(serverName);
         if (server != null) {
             PersonalAccessToken credentials = server.getCredentials();
+            String serverUrl = server.getServerUrl();
             if (credentials != null) {
-                return new GitLabApi(server.getServerUrl(), credentials.getToken().getPlainText(), null, getProxyConfig());
+                return new GitLabApi(serverUrl, credentials.getToken().getPlainText(), null, getProxyConfig(serverUrl));
             }
-            return new GitLabApi(server.getServerUrl(), GitLabServer.EMPTY_TOKEN, null, getProxyConfig());
+            return new GitLabApi(serverUrl, GitLabServer.EMPTY_TOKEN, null, getProxyConfig(serverUrl));
         }
         throw new IllegalStateException(
             String.format("No server found with the name: %s", serverName));
     }
 
-    public static Map<String, Object> getProxyConfig () {
+    public static Map<String, Object> getProxyConfig (String serverUrl) {
         ProxyConfiguration proxyConfiguration = Jenkins.get().getProxy();
         if (proxyConfiguration != null) {
+                final URL url;
+                try {
+                    url = new URL(serverUrl);
+                } catch (MalformedURLException e) {
+                    // let it crash somewhere else
+                    return null;
+                }
+                if (!"http".equals(url.getProtocol()) && !"https".equals(url.getProtocol())) {
+                    // non-http(s) URL, proxy won't handle it
+                    return null;
+                }
+                List<Pattern> nonProxyHostPatterns = proxyConfiguration.getNoProxyHostPatterns();
+                if (nonProxyHostPatterns.stream().anyMatch(p -> p.matcher(url.getHost()).matches())) {
+                    // target host is excluded by proxy configuration
+                    return null;
+                }
             if (proxyConfiguration.getUserName() != null && proxyConfiguration.getSecretPassword() != null) {
                 return ProxyClientConfig.createProxyClientConfig(
                     "http://" + proxyConfiguration.getName() + ":" + proxyConfiguration.getPort(),

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -309,7 +309,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
             if (GITLAB_SERVER_URL.equals(serverUrl)) {
                 LOGGER.log(Level.FINEST, String.format("Community version of GitLab: %s", serverUrl));
             }
-            GitLabApi gitLabApi = new GitLabApi(serverUrl, "", null, getProxyConfig());
+            GitLabApi gitLabApi = new GitLabApi(serverUrl, "", null, getProxyConfig(serverUrl));
             try {
                 gitLabApi.getProjectApi().getProjects(1, 1);
                 return FormValidation.ok();
@@ -361,7 +361,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
                 privateToken = credentials.getToken().getPlainText();
             }
             if (privateToken.equals(EMPTY_TOKEN)) {
-                GitLabApi gitLabApi = new GitLabApi(serverUrl, EMPTY_TOKEN, null, getProxyConfig());
+                GitLabApi gitLabApi = new GitLabApi(serverUrl, EMPTY_TOKEN, null, getProxyConfig(serverUrl));
                 try {
                     /*
                     In order to validate a GitLab Server without personal access token,
@@ -379,7 +379,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
                 }
             } else {
 
-                GitLabApi gitLabApi = new GitLabApi(serverUrl, privateToken, null, getProxyConfig());
+                GitLabApi gitLabApi = new GitLabApi(serverUrl, privateToken, null, getProxyConfig(serverUrl));
                 try {
                     User user = gitLabApi.getUserApi().getCurrentUser();
                     LOGGER.log(Level.FINEST, String


### PR DESCRIPTION
See [JENKINS-62779](https://issues.jenkins.io/browse/JENKINS-62779).

This is a follow-up to #124, recently released in [1.5.5](https://github.com/jenkinsci/gitlab-branch-source-plugin/releases/tag/gitlab-branch-source-1.5.5).  This PR has introduced support for using an HTTP proxy server (the one configured in the Jenkins Update Center settings) when connecting to a GitLab server.  But the proxy exclusions settings (the "_No Proxy Host_" list) is ignored with this implementation. Quoting @jbdelpech:
> Unfortunately, ProxyClientConfig does not support no_proxy parameter. At least, there is few chance to have multiple gitlab servers behind proxy and directly reachable.

So, this was actually an improvement for some users, but also a regression for some others:
- people stuck behind a corporate proxy for internet access, who want to reach _gitlab.com_ => 1.5.5 fixes their use case
- people stuck behind a corporate proxy for internet access, who want to reach an internal (on-premise) GitLab server => used to work fine up to 1.5.4, may break with 1.5.5 (if the proxy is restricted to internet only). And deconfiguring the Jenkins Update Center proxy is not an option, since these settings are not specific to the GitLab Branch Source plugin (they're used by many other plugins, by some core features like some tools installers, and by the Update Center itself).

This PR adds support for taking the "no proxy" hosts list into account. We know the target GitLab server host, thus we can test whether it matches the proxy exclusions list or not, and if it does we can avoid passing proxy properties to the gitlab4j API.
A trick for testing the "no proxy" hosts list for a given target host is to use [`ProxyConfiguration.getNoProxyHostPatterns()`](https://github.com/jenkinsci/jenkins/blob/901bf54db6af7d22a94246b0b25c3ef579b7efd3/core/src/main/java/hudson/ProxyConfiguration.java#L204) (see [usage examples](https://github.com/search?q=org%3Ajenkinsci+getNoProxyHostPatterns&type=code)).

There are no new unit tests in this PR. I only did minimal manual testing via the "Test Connection" button with different proxy settings, and also checked that existing unit tests are still okay.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

CC for review: @jbdelpech, @markyjackson-taulia and @EugeneLesnov (from #124), and @LinuxSuRen (because this fixes a regression of the recently released version 1.5.5)