### PR TITLE
Fix pipeline branch ref when building a merge request

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
@@ -53,9 +53,9 @@ public class GitLabPipelineStatusNotifier {
     private static final Logger LOGGER = Logger
         .getLogger(GitLabPipelineStatusNotifier.class.getName());
 
-    private static final String GITLAB_PIPELINE_STATUS_PREFIX = "jenkinsci";
+    static final String GITLAB_PIPELINE_STATUS_PREFIX = "jenkinsci";
 
-    private static final String GITLAB_PIPELINE_STATUS_DELIMITER = "/";
+    static final String GITLAB_PIPELINE_STATUS_DELIMITER = "/";
 
     private static String getRootUrl(Run<?, ?> build) {
         try {
@@ -87,7 +87,7 @@ public class GitLabPipelineStatusNotifier {
         return getStatusName(sourceContext, job.getFullDisplayName(), revision);
     }
 
-    private static String getStatusName(final GitLabSCMSourceContext sourceContext, final String fullDisplayName, final SCMRevision revision) {
+    static String getStatusName(final GitLabSCMSourceContext sourceContext, final String fullDisplayName, final SCMRevision revision) {
         final String type;
         if (revision instanceof BranchSCMRevision) {
             type = "branch";
@@ -110,6 +110,17 @@ public class GitLabPipelineStatusNotifier {
         final String statusName = GITLAB_PIPELINE_STATUS_PREFIX + GITLAB_PIPELINE_STATUS_DELIMITER + customPrefix + type;
         LOGGER.log(Level.FINEST, () -> "Retrieved status name is: " + statusName);
         return statusName;
+    }
+
+    static String getRevisionRef(final SCMRevision revision) {
+        final String refName;
+        if (revision instanceof MergeRequestSCMRevision) {
+            refName = ((MergeRequestSCMRevision) revision).getOrigin().getHead().getName();
+        } else {
+            refName = revision.getHead().getName();
+        }
+        LOGGER.log(Level.FINEST, () -> "Retrieved revision ref is: " + refName);
+        return refName;
     }
 
     private static String getMrBuildName(final String buildName) {
@@ -264,7 +275,7 @@ public class GitLabPipelineStatusNotifier {
             return;
         }
         status.setName(getStatusName(sourceContext, build, revision));
-        status.setRef(revision.getHead().getName());
+        status.setRef(getRevisionRef(revision));
 
         final JobScheduledListener jsl = ExtensionList.lookup(QueueListener.class)
             .get(JobScheduledListener.class);
@@ -348,7 +359,7 @@ public class GitLabPipelineStatusNotifier {
                         return;
                     }
                     status.setName(getStatusName(sourceContext, job, revision));
-                    status.setRef(revision.getHead().getName());
+                    status.setRef(getRevisionRef(revision));
 
                     String url;
                     try {

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifierTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifierTest.java
@@ -1,0 +1,121 @@
+package io.jenkins.plugins.gitlabbranchsource.helpers;
+
+import io.jenkins.plugins.gitlabbranchsource.BranchSCMHead;
+import io.jenkins.plugins.gitlabbranchsource.BranchSCMRevision;
+import io.jenkins.plugins.gitlabbranchsource.GitLabSCMSourceContext;
+import io.jenkins.plugins.gitlabbranchsource.MergeRequestSCMHead;
+import io.jenkins.plugins.gitlabbranchsource.MergeRequestSCMRevision;
+import jenkins.plugins.git.GitTagSCMHead;
+import jenkins.plugins.git.GitTagSCMRevision;
+import jenkins.scm.api.SCMRevision;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class GitLabPipelineStatusNotifierTest {
+
+    @Test
+    public void should_set_branch_status_name() {
+        GitLabSCMSourceContext sourceContext = new GitLabSCMSourceContext(null, null);
+
+        BranchSCMHead head = new BranchSCMHead("head");
+        SCMRevision revision = new BranchSCMRevision(head, "hash");
+
+        String statusName = GitLabPipelineStatusNotifier.getStatusName(sourceContext, null, revision);
+
+        assertThat(statusName, is(GitLabPipelineStatusNotifier.GITLAB_PIPELINE_STATUS_PREFIX
+                + GitLabPipelineStatusNotifier.GITLAB_PIPELINE_STATUS_DELIMITER
+                + "branch"));
+    }
+
+    @Test
+    public void should_set_merge_request_head_status_name() {
+        GitLabSCMSourceContext sourceContext = new GitLabSCMSourceContext(null, null);
+
+        BranchSCMHead targetHead = new BranchSCMHead("target");
+        MergeRequestSCMHead head = new MergeRequestSCMHead("head", 0, targetHead, null, null, null, null, null, null);
+
+        BranchSCMRevision target = new BranchSCMRevision(targetHead, "target-hash");
+        BranchSCMRevision source = new BranchSCMRevision(new BranchSCMHead("source"), "source-hash");
+        SCMRevision revision = new MergeRequestSCMRevision(head, target, source);
+
+        String statusName = GitLabPipelineStatusNotifier.getStatusName(sourceContext, "head", revision);
+
+        assertThat(statusName, is(GitLabPipelineStatusNotifier.GITLAB_PIPELINE_STATUS_PREFIX
+                + GitLabPipelineStatusNotifier.GITLAB_PIPELINE_STATUS_DELIMITER
+                + "mr-head"));
+    }
+
+    @Test
+    public void should_set_merge_request_merge_status_name() {
+        GitLabSCMSourceContext sourceContext = new GitLabSCMSourceContext(null, null);
+
+        BranchSCMHead targetHead = new BranchSCMHead("target");
+        MergeRequestSCMHead head = new MergeRequestSCMHead("head", 0, targetHead, null, null, null, null, null, null);
+
+        BranchSCMRevision target = new BranchSCMRevision(targetHead, "target-hash");
+        BranchSCMRevision source = new BranchSCMRevision(new BranchSCMHead("source"), "source-hash");
+        SCMRevision revision = new MergeRequestSCMRevision(head, target, source);
+
+        String statusName = GitLabPipelineStatusNotifier.getStatusName(sourceContext, "merge", revision);
+
+        assertThat(statusName, is(GitLabPipelineStatusNotifier.GITLAB_PIPELINE_STATUS_PREFIX
+                + GitLabPipelineStatusNotifier.GITLAB_PIPELINE_STATUS_DELIMITER
+                + "mr-merge"));
+    }
+
+    @Test
+    public void should_set_tag_status_name() {
+        GitLabSCMSourceContext sourceContext = new GitLabSCMSourceContext(null, null);
+
+        GitTagSCMHead head = new GitTagSCMHead("tagName", 0);
+        SCMRevision revision = new GitTagSCMRevision(head, "tag-hash");
+
+        String statusName = GitLabPipelineStatusNotifier.getStatusName(sourceContext, null, revision);
+
+        assertThat(statusName, is(GitLabPipelineStatusNotifier.GITLAB_PIPELINE_STATUS_PREFIX
+                + GitLabPipelineStatusNotifier.GITLAB_PIPELINE_STATUS_DELIMITER
+                + "tag"));
+    }
+
+    @Test
+    public void should_set_branch_ref_name() {
+        String branchName = "branch_name";
+        BranchSCMHead head = new BranchSCMHead(branchName);
+        SCMRevision revision = new BranchSCMRevision(head, "hash");
+
+        String refName = GitLabPipelineStatusNotifier.getRevisionRef(revision);
+
+        assertThat(refName, is(branchName));
+    }
+
+    @Test
+    public void should_set_merge_request_ref_name() {
+        String sourceBranchName = "sourceBranchName";
+        String targetBranchName = "targetBranchName";
+
+        BranchSCMHead targetHead = new BranchSCMHead(targetBranchName);
+        MergeRequestSCMHead head = new MergeRequestSCMHead("MR-123", 0, targetHead, null, null, null, null, null, null);
+
+        BranchSCMRevision target = new BranchSCMRevision(targetHead, "target-hash");
+        BranchSCMRevision source = new BranchSCMRevision(new BranchSCMHead(sourceBranchName), "source-hash");
+        SCMRevision revision = new MergeRequestSCMRevision(head, target, source);
+
+        String refName = GitLabPipelineStatusNotifier.getRevisionRef(revision);
+
+        assertThat(refName, is(sourceBranchName));
+    }
+
+    @Test
+    public void should_set_tag_ref_name() {
+        String tagName = "tagName";
+        GitTagSCMHead head = new GitTagSCMHead(tagName, 0);
+        SCMRevision revision = new GitTagSCMRevision(head, "tag-hash");
+
+        String refName = GitLabPipelineStatusNotifier.getRevisionRef(revision);
+
+        assertThat(refName, is(tagName));
+    }
+
+}


### PR DESCRIPTION

Fixes #135, follow-up to #128 

Correctly uses the source branch ref when building a merge request so gitlab associates it correctly with the merge request.
I've also added some unit tests.

Last, I've tested it live on jenkins with gitlab to make sure the merge request saw the pipeline was started.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

