### PR TITLE
Add pagination to getBranches call

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -76,6 +76,7 @@ import org.apache.commons.lang.StringUtils;
 import org.gitlab4j.api.Constants;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.Pager;
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.Branch;
 import org.gitlab4j.api.models.Member;
@@ -316,7 +317,9 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 request.setProject(gitlabProject);
                 request.setMembers(getMembers());
                 if (request.isFetchBranches()) {
-                    request.setBranches(gitLabApi.getRepositoryApi().getBranches(gitlabProject));
+                    Pager<Branch> branchesPager = gitLabApi.getRepositoryApi().getBranches(gitlabProject, null, 10);
+                    List<Branch> branches = branchesPager.all();
+                    request.setBranches(branches);
                 }
                 if (request.isFetchMRs()) {
                     // If not authenticated GitLabApi cannot detect if it is a fork


### PR DESCRIPTION
We have over 200 branches in some of our repos (yes, I know that's bad). This plugin is failing to retrieve all the branches and as a result will often remove master etc. This change adds pagination to the getBranches call.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira - https://issues.jenkins.io/browse/JENKINS-65760