### PR TITLE
Allow users without global Job/Build permission configure multibranch jobs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target
 .settings
 bin
 .DS_Store
+.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ target
 .settings
 bin
 .DS_Store
-.vscode/*
+.vscode/

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -37,7 +37,7 @@ public class GitLabHookCreator {
                 if (!server.isManageSystemHooks()) {
                     return;
                 }
-                credentials = server.getCredentials();
+                credentials = server.getCredentials(owner);
                 if (credentials == null) {
                     LOGGER.log(Level.WARNING, "No System credentials added, cannot create system hook");
                 }
@@ -71,7 +71,7 @@ public class GitLabHookCreator {
                 if (!server.isManageWebHooks()) {
                     break;
                 }
-                credentials = server.getCredentials();
+                credentials = server.getCredentials(source.getOwner());
                 if (credentials == null) {
                     LOGGER.log(Level.WARNING, "No System credentials added, cannot create web hook");
                 }
@@ -108,7 +108,7 @@ public class GitLabHookCreator {
                 if (!server.isManageSystemHooks()) {
                     return;
                 }
-                credentials = server.getCredentials();
+                credentials = server.getCredentials(source.getOwner());
                 if (credentials == null) {
                     LOGGER.log(Level.WARNING, "No System credentials added, cannot create system hook");
                 }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
@@ -97,7 +97,7 @@ public class GitLabSCMFileSystem extends SCMFileSystem {
            @CheckForNull SCMRevision rev)
            throws IOException, InterruptedException {
             GitLabSCMSource gitlabScmSource = (GitLabSCMSource) source;
-            GitLabApi gitLabApi = apiBuilder(gitlabScmSource.getServerName());
+            GitLabApi gitLabApi = apiBuilder(source.getOwner(), gitlabScmSource.getServerName());
             String projectPath = gitlabScmSource.getProjectPath();
             return build(head, rev, gitLabApi, projectPath);
         }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -193,7 +193,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
 
     protected Project getGitlabProject() {
         if (gitlabProject == null) {
-            getGitlabProject(apiBuilder(serverName));
+            getGitlabProject(apiBuilder(this.getOwner(), serverName));
         }
         return gitlabProject;
     }
@@ -216,7 +216,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     public HashMap<String, AccessLevel> getMembers() {
         HashMap<String, AccessLevel> members = new HashMap<>();
         try {
-            GitLabApi gitLabApi = apiBuilder(serverName);
+            GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName);
             for (Member m : gitLabApi.getProjectApi().getAllMembers(projectPath)) {
                 members.put(m.getUsername(), m.getAccessLevel());
             }
@@ -251,7 +251,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     protected SCMRevision retrieve(@NonNull SCMHead head, @NonNull TaskListener listener)
             throws IOException, InterruptedException {
         try {
-            GitLabApi gitLabApi = apiBuilder(serverName);
+            GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName);
             getGitlabProject(gitLabApi);
             if (head instanceof BranchSCMHead) {
                 listener.getLogger().format("Querying the current revision of branch %s...%n", head.getName());
@@ -304,7 +304,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         SCMHeadEvent<?> event,
         @NonNull TaskListener listener) throws IOException, InterruptedException {
         try {
-            GitLabApi gitLabApi = apiBuilder(serverName);
+            GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName);
             getGitlabProject(gitLabApi);
             setProjectId(gitlabProject.getId());
             sshRemote = gitlabProject.getSshUrlToRepo();
@@ -675,7 +675,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             if (builder == null) {
                 throw new AssertionError();
             }
-            GitLabApi gitLabApi = apiBuilder(serverName);
+            GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName);
             getGitlabProject(gitLabApi);
             final SCMFileSystem fs = builder.build(head, revision, gitLabApi, projectPath);
             return new SCMProbe() {
@@ -807,7 +807,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             return result;
         }
 
-        public long getProjectId(@QueryParameter String projectPath, @QueryParameter String serverName) {
+        public long getProjectId(@AncestorInPath SCMSourceOwner context, @QueryParameter String projectPath, @QueryParameter String serverName) {
             List<GitLabServer> gitLabServers = GitLabServers.get().getServers();
             if (gitLabServers.size() == 0) {
                 return -1;
@@ -815,9 +815,9 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             try {
                 GitLabApi gitLabApi;
                 if (StringUtils.isBlank(serverName)) {
-                    gitLabApi = apiBuilder(gitLabServers.get(0).getName());
+                    gitLabApi = apiBuilder(context, gitLabServers.get(0).getName());
                 } else {
-                    gitLabApi = apiBuilder(serverName);
+                    gitLabApi = apiBuilder(context, serverName);
                 }
                 if (StringUtils.isNotBlank(projectPath)) {
                     return gitLabApi.getProjectApi().getProject(projectPath).getId();
@@ -838,9 +838,9 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             try {
                 GitLabApi gitLabApi;
                 if (serverName.equals("")) {
-                    gitLabApi = apiBuilder(gitLabServers.get(0).getName());
+                    gitLabApi = apiBuilder(context, gitLabServers.get(0).getName());
                 } else {
-                    gitLabApi = apiBuilder(serverName);
+                    gitLabApi = apiBuilder(context, serverName);
                 }
 
                 if (projectOwner.equals("")) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
@@ -4,6 +4,7 @@ import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.UriTemplateBuilder;
 import com.damnhandy.uri.template.impl.Operator;
 import hudson.ProxyConfiguration;
+import hudson.security.AccessControlled;
 import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
@@ -19,10 +20,10 @@ import org.gitlab4j.api.ProxyClientConfig;
 
 public class GitLabHelper {
 
-    public static GitLabApi apiBuilder(String serverName) {
+    public static GitLabApi apiBuilder(AccessControlled context, String serverName) {
         GitLabServer server = GitLabServers.get().findServer(serverName);
         if (server != null) {
-            PersonalAccessToken credentials = server.getCredentials();
+            PersonalAccessToken credentials = server.getCredentials(context);
             String serverUrl = server.getServerUrl();
             if (credentials != null) {
                 return new GitLabApi(serverUrl, credentials.getToken().getPlainText(), null, getProxyConfig(serverUrl));

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
@@ -174,7 +174,7 @@ public class GitLabPipelineStatusNotifier {
         String suffix = " - [Details](" + url + ")";
         SCMRevision revision = SCMRevisionAction.getRevision(source, build);
         try {
-            GitLabApi gitLabApi = GitLabHelper.apiBuilder(source.getServerName());
+            GitLabApi gitLabApi = GitLabHelper.apiBuilder(build.getParent(), source.getServerName());
             String sudoUsername = sourceContext.getSudoUser();
             if (!sudoUsername.isEmpty()) {
                 gitLabApi.sudo(sudoUsername);
@@ -319,7 +319,7 @@ public class GitLabPipelineStatusNotifier {
             }
         }
         try {
-            GitLabApi gitLabApi = GitLabHelper.apiBuilder(source.getServerName());
+            GitLabApi gitLabApi = GitLabHelper.apiBuilder(build.getParent(), source.getServerName());
             LOGGER.log(Level.FINE, String.format("Notifiying commit: %s", hash));
 
             if (revision instanceof MergeRequestSCMRevision) {
@@ -419,7 +419,7 @@ public class GitLabPipelineStatusNotifier {
 
                     Constants.CommitBuildState state = Constants.CommitBuildState.PENDING;
                     try {
-                        GitLabApi gitLabApi = GitLabHelper.apiBuilder(source.getServerName());
+                        GitLabApi gitLabApi = GitLabHelper.apiBuilder(job, source.getServerName());
                         // check are we still the task to set pending
                         synchronized (resolving) {
                             if (!nonce.equals(resolving.get(job))) {

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/action/GitlabAction.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/action/GitlabAction.java
@@ -9,6 +9,7 @@ import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
+import jenkins.scm.api.SCMSourceOwner;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
@@ -18,6 +19,7 @@ import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.ProjectFilter;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -48,7 +50,8 @@ public class GitlabAction implements RootAction {
     }
 
     @RequirePOST
-    public HttpResponse doProjectList(@QueryParameter String server,
+    public HttpResponse doProjectList(@AncestorInPath SCMSourceOwner context,
+        @QueryParameter String server,
         @QueryParameter String owner) {
         if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
             return HttpResponses.errorJSON("no permission to get Gitlab server list");
@@ -60,7 +63,7 @@ public class GitlabAction implements RootAction {
 
         JSONArray servers = new JSONArray();
 
-        GitLabApi gitLabApi = GitLabHelper.apiBuilder(server);
+        GitLabApi gitLabApi = GitLabHelper.apiBuilder(context, server);
         try {
             for (Project project : gitLabApi.getProjectApi().getUserProjects(owner,
                 new ProjectFilter().withOwned(true))) {


### PR DESCRIPTION
Hello!

If somebody install gitlab-branch-source-plugin with authorization plugin (like Folder Authorization Plugin or Role-based Authorization Strategy), they might grant permission Job/Build on certain jobs without granting global permission Job/Build.  
In this case, user with this permissions will get error: 
```Error while serving https://jenkins.vimpelcom.ru/job/test/job/test2/descriptorByName/io.jenkins.plugins.gitlabbranchsource.GitLabSCMSource/fillProjectPathItems
hudson.security.AccessDeniedException3: <username> is missing the Job/Build permission
  at hudson.security.ACL.checkPermission(ACL.java:79)
  at hudson.security.AccessControlled.checkPermission(AccessControlled.java:47)
  at io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer.getCredentials(GitLabServer.java:229)
  at io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.apiBuilder(GitLabHelper.java:25)
  at io.jenkins.plugins.gitlabbranchsource.GitLabSCMSource$DescriptorImpl.doFillProjectPathItems(GitLabSCMSource.java:843)
  at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:710)
  at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:396)
Caused: java.lang.reflect.InvocationTargetException
...
```

This caused by check permission onli on Jenkins singleton in this line:
https://github.com/jenkinsci/gitlab-branch-source-plugin/blob/ae2e6e7b58b11c3cf6435c4727367682770ac0a9/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java#L229

[Documetation ](https://www.jenkins.io/doc/developer/security/) said: 
> Identify the nearest AccessControlled objects to check permissions with. If your 'this' object is already access-controlled, then that’s obviously it. Otherwise, try to look for the nearest logical ancestor. If all else fails, use the Jenkins singleton.

In this PR I try to fix AccessDeniedException by:
- Identify AccessControlled objects in methods which use static method [apiBuilder()](https://github.com/jenkinsci/gitlab-branch-source-plugin/blob/ae2e6e7b58b11c3cf6435c4727367682770ac0a9/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java#L22)
- Pass this objects in [apiBuilder()](https://github.com/jenkinsci/gitlab-branch-source-plugin/blob/ae2e6e7b58b11c3cf6435c4727367682770ac0a9/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java#L22) and [getCredentials()](https://github.com/jenkinsci/gitlab-branch-source-plugin/blob/ae2e6e7b58b11c3cf6435c4727367682770ac0a9/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java#L227)
- Check permission on this objects or on Jenkins singleton if they is null in [getCredentials()](https://github.com/jenkinsci/gitlab-branch-source-plugin/blob/ae2e6e7b58b11c3cf6435c4727367682770ac0a9/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java#L227).

Fixes: 
[JENKINS-62478](https://issues.jenkins.io/browse/JENKINS-62478)
