### PR TITLE
Add options to prevent un-needed pipeline runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ you require the following plugins:
 * GitLab Branch Source Plugin - Contains two packages:
 
      * `io.jenkins.plugins.gitlabserverconfig` - Manages server configuration and web hooks management. Ideally should reside inside another plugin with name `GitLab Plugin`. In future, this package will be moved into a new plugin.
-     
+
      * `io.jenkins.plugins.gitlabbranchsource` - Adds GitLab Branch Source for Multi-branch Pipeline Jobs (including
      Merge Requests) and Folder organisation.
 
@@ -83,7 +83,7 @@ Here are a few ways to setup your own Jenkins server:
     Refer to Bitnami [docs](https://docs.bitnami.com/general/apps/jenkins/).
 
 5. Using [Jenkins CLI](https://github.com/jenkins-zh/jenkins-cli) run it for development:
-    
+
     Run it via: `jcli plugin run`
 
 ### Configuring Jenkins instance:
@@ -121,7 +121,7 @@ Here are a few ways to setup your own Jenkins server:
 You can use any one of these ways:
 
 1. Install from Jenkins Update Center. Go to Jenkins > Configure > Manage Plugins > Available and search for `gitlab branch source plugin` then select Install.
-    
+
 2. Using [Plugin Management Tool](https://github.com/jenkinsci/plugin-installation-manager-tool)
 
     ```bash
@@ -134,12 +134,12 @@ You can use any one of these ways:
 3. From Source:
 
     i. Checkout out source code to your local machine:
-    
+
     ```
     git clone https://github.com/jenkinsci/gitlab-branch-source-plugin.git
     cd gitlab-branch-source-plugin
     ```
-    
+
     ii. Install the plugin:
     ```
     mvn clean install
@@ -148,7 +148,7 @@ You can use any one of these ways:
     ```
 
     iii. Run the Plugin:
-    
+
     ```
     mvn hpi:run # runs a Jenkins instance at localhost:8080
         or
@@ -201,9 +201,9 @@ After installing the plugin on your Jenkins instance, you need configure your Gi
 
     iii. `Credentials` - Contains a list of credentials entries that are of type GitLab Personal Access Token. When no credential has been added it shows "-none-". User can add a credential by clicking "Add" button.
 
-    iv. `Mange Web Hook` - If you want the plugin to setup web hook on your GitLab project(s) to get push/mr/tag/note events then check this box. 
-    
-    iv. `Mange System Hook` - If you want the plugin to setup system hook on your GitLab project(s) to detect if a project is removed then check this box. Remember plugin can only setup system hook on your server if supplied access token has `Admin` access. 
+    iv. `Mange Web Hook` - If you want the plugin to setup web hook on your GitLab project(s) to get push/mr/tag/note events then check this box.
+
+    iv. `Mange System Hook` - If you want the plugin to setup system hook on your GitLab project(s) to detect if a project is removed then check this box. Remember plugin can only setup system hook on your server if supplied access token has `Admin` access.
 
     v. `Secret Token` - The secret token is required to authenticate the webhook payloads received from GitLab Server. Use generate secret token from Advanced options or use your own. If you are a old plugin user and did not set a secret token previously and want secret token to applied to the hooks of your existing jobs, you can add the secret token and rescan your jobs. Existing hooks with new secret token will be applied.
 
@@ -283,7 +283,7 @@ GitLab Personal Access Token credentials to Jenkins server credentials.
 7. The token creator will create a Personal Access Token in your GitLab Server for the given user with the required scope and also create a credentials for the same inside Jenkins server. You can go back to the GitLab Server Configuration to select the new credentials generated (select "-none-" first then new credentials will appear). For security reasons this token is not revealed as plain text rather returns an `id`. It is a 128-bit long UUID-4 string (36 characters).
 
     ![gitlab-token-creator](/docs/img/gitlab-token-creator.png)
-    
+
 ### Manually create hooks on GitLab Server
 
 Use the following end points for web hooks and system hooks setup on your GitLab Server. The `Jenkins Url` needs to be a fully qualified domain name (FQDN) so cannot be `localhost`.
@@ -379,17 +379,17 @@ To create a `Multibranch Pipeline Job`:
 3. In `Branch Sources` sections, select `Add source` | select `GitLab Project`.
 
 4. Now you need to configure your jobs.
- 
+
     ![branch-source](/docs/img/branch-source.png)
-    
+
     i. Select `Server` configured in the initial server setup.
-    
+
     ii. [Optional] Add `Checkout Credentials` (SSHPrivateKey or Username/Password) if there is any private projects that will be built by the plugin.
-    
+
     iii. Add path to the owner where the project you want to build exists. If user, enter `username`. If group, enter `group name`. If subgroup, enter `subgroup path with namespace`.
-    
+
     iv. Based on the owner provided. All the projects are discovered in the path and added to the `Projects` listbox. You can now choose the project you want to build.
-    
+
     v. `Behaviours` (a.k.a. SCM Traits) allow different configurations option to your build. More about it in the SCM Trait APIs section.
 
 5. Now you can go ahead and save the job.
@@ -402,7 +402,7 @@ The Job results are notified to the GitLab Server as Pipeline Status for the HEA
 
 We have a workaround for this. Jenkins will build the MRs from forked projects if the MR author is a trusted owner i.e. has `Developer`/`Maintainer`/`Owner` access level. More about it in the SCM Trait APIs section.
 
-As the web hook is now setup on your Jenkins CI by the GitLab server. Any push-events or merge-request events or tag events trigger the concerned build in Jenkins. 
+As the web hook is now setup on your Jenkins CI by the GitLab server. Any push-events or merge-request events or tag events trigger the concerned build in Jenkins.
 
 ### Folder Organization
 
@@ -415,7 +415,7 @@ To create a `GitLab Group Job`:
 2. Enter a name for your job, select `GitLab Group` | select `Ok`.
 
 3. Now you need to configure your jobs.
-    
+
     i. Select `Server` configured in the initial server setup.
 
     ii. [Optional] Add `Checkout Credentials` (SSHPrivateKey or Username/Password) only if there are any private projects required to be built.
@@ -439,7 +439,7 @@ The following behaviours apply to both `Multibranch Pipeline Jobs` and `Folder O
 	* `All Branches` - Ignores whether the branch is also filed as a merge request and instead discovers all branches on the origin project.
 
 * `Discover merge requests from origin` - To discover merge requests made from origin branches.
-	
+
 	* `Merging the merge request merged with current target revision` - Discover each merge request once with the discovered revision corresponding to the result of merging with the current revision of the target branch.
 	* `The current merge request revision` - Discover each merge request once with the discovered revision corresponding to the merge request head revision without merging.
 	* `Both current mr revision and the mr merged with current target revision` - Discover each merge request twice. The first discovered revision corresponds to the result of merging with the current revision of the target branch in each scan. The second parallel discovered revision corresponds to the merge request head revision without merging.
@@ -447,18 +447,18 @@ The following behaviours apply to both `Multibranch Pipeline Jobs` and `Folder O
 * `Discover merge requests from forks` - To discover merge requests made from forked project branches.
 
 	* Strategy:
-	
+
 		* `Merging the merge request merged with current target revision` - Discover each merge request once with the discovered revision corresponding to the result of merging with the current revision of the target branch.
 		* `The current merge request revision` - Discover each merge request once with the discovered revision corresponding to the merge request head revision without merging.
 		* `Both current mr revision and the mr merged with current target revision` - Discover each merge request twice. The first discovered revision corresponds to the result of merging with the current revision of the target branch in each scan. The second parallel discovered revision corresponds to the merge request head revision without merging.
-		
+
 	* Trust
-	
+
 		* `Members` - Discover MRs from Forked Projects whose author is a member of the origin project.
 		* `Trusted Members` - [Recommended] Discover MRs from Forked Projects whose author is has Developer/Maintainer/Owner accesslevel in the origin project.
 		* `Everyone` - Discover MRs from Forked Projects filed by anybody. For security reasons you should never use this option. It may be used to reveal your Pipeline secrets environment variables.
 		* `Nobody` - Discover no MRs from Forked Projects at all. Equivalent to removing the trait altogether.
-		
+
 	If `Members` or `Trusted Members` is selected, then plugin will build the target branch of MRs from non/untrusted members.
 
 ### Additional Traits:
@@ -469,7 +469,7 @@ These traits can be selected by selecting `Add` in the `Behaviours` section.
 
 * `Discover group/subgroup projects` - Discover subgroup projects inside a group/subgroup. Only applicable to `GitLab Group` Job type whose owner is a `Group`/`Subgroup` but not `User`.
 
-* `Log build status as comment on GitLab` - Enable logging build status as comment on GitLab. A comment is logged on the commit or merge request once the build is completed. You can decide if you want to log success builds or not. You can also use sudo user to comment the build status as commment e.g. `jenkinsadmin` or something similar. 
+* `Log build status as comment on GitLab` - Enable logging build status as comment on GitLab. A comment is logged on the commit or merge request once the build is completed. You can decide if you want to log success builds or not. You can also use sudo user to comment the build status as commment e.g. `jenkinsadmin` or something similar.
 
 * `Trigger build on merge request comment` - Enable trigger a rebuild of a merge request by comment with your desired comment body (default: `jenkins rebuild`). The job can only be triggered by trusted members of the project i.e. users with Developer/Maintainer/Owner accesslevel (also includes inherited from ancestor groups). By default only trusted members of project can trigger MR.
 You may want to disable this option because trusted members do not include members inherited from shared group (there is no way to get it from GitLabApi as of GitLab 13.0.0). If disabled, MR comment trigger can be done by any user having access to your project.
@@ -488,6 +488,8 @@ You may want to disable this option because trusted members do not include membe
 
 * `Checkout over SSH` - [Not Recommended] Use this mode to checkout over SSH. Use `Checkout Credentials` instead.
 
+* `Webhook Listener Conditions` - Set conditions based on the webhook content on when a build should be triggered.
+
 ## Environment Variables
 
 By default Multibranch Jobs have the following environment variables (provided by Branch API Plugin):
@@ -498,19 +500,19 @@ Merge Request - `BRANCH_NAME`, `CHANGE_ID`, `CHANGE_TARGET`, `CHANGE_BRANCH`, `C
 
 Tag - `BRANCH_NAME`, `TAG_NAME`, `TAG_TIMESTAMP`, `TAG_DATE`, `TAG_UNIXTIME`
 
-This plugin adds a few more environment variables to Builds (`WorkflowRun` type only) which is the payload received as WebHook) See https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#events. 
+This plugin adds a few more environment variables to Builds (`WorkflowRun` type only) which is the payload received as WebHook) See https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#events.
 
-A few points to note: 
+A few points to note:
 
 > If no response is recorded for any field in the Web Hook Payload, it returns an empty String. To add more variables see `package io.jenkins.plugins.gitlabbranchsource.Cause`.
-> 
+>
 > `GITLAB_OBJECT_KIND` - This environment variable should be used to check the event type before accessing the environment variables. Possible values are `none`, `push`, `tag_push` and `merge_request`.
 >
 > Any variables ending with `#` indicates the index of the list of the payload starting from 1.
 
 Environment Variables are available from Push Event, Tag Push Event and Merge Request Event.
 
-### Push Event: 
+### Push Event:
 
 See https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#push-events
 
@@ -576,12 +578,12 @@ GITLAB_REFS_HEAD
 
 ### Tag Event:
 
-Note: 
-> Jenkins by default refrains from automatically building Tags on push ([See reason](https://issues.jenkins-ci.org/browse/JENKINS-47496?focusedCommentId=332369&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-332369)). You need to install Branch Build Strategy Plugin to solve this. 
-> 
+Note:
+> Jenkins by default refrains from automatically building Tags on push ([See reason](https://issues.jenkins-ci.org/browse/JENKINS-47496?focusedCommentId=332369&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-332369)). You need to install Branch Build Strategy Plugin to solve this.
+>
 > See Guide: https://github.com/jenkinsci/basic-branch-build-strategies-plugin/blob/master/docs/user.adoc
 >
-> Do remember if you are using Basic Branch Build for tag builds you also need to add strategies for branch and pull request (change request) else they would not be automatically built (See GIF below). 
+> Do remember if you are using Basic Branch Build for tag builds you also need to add strategies for branch and pull request (change request) else they would not be automatically built (See GIF below).
 
 ![branch-build-strategy](/docs/img/branch-build-strategy.gif)
 
@@ -775,7 +777,7 @@ organizationFolder('GitLab Organization Folder') {
     // "Traits" ("Behaviours" in the GUI) that are NOT "declarative-compatible"
     // For some 'traits, we need to configure this stuff by hand until JobDSL handles it
     // https://issues.jenkins.io/browse/JENKINS-45504
-    configure { 
+    configure {
         def traits = it / navigators / 'io.jenkins.plugins.gitlabbranchsource.GitLabSCMNavigator' / traits
         traits << 'io.jenkins.plugins.gitlabbranchsource.ForkMergeRequestDiscoveryTrait' {
             strategyId(2)
@@ -894,10 +896,10 @@ This plugin is built and maintained by the Google Summer of Code (GSoC) Team for
 
 Maintainers:
 
-* [Parichay](https://github.com/baymac) 
-* [Marky](https://github.com/markyjackson-taulia) 
-* [Joseph](https://github.com/casz) 
-* [Justin](https://github.com/justinharringa) 
+* [Parichay](https://github.com/baymac)
+* [Marky](https://github.com/markyjackson-taulia)
+* [Joseph](https://github.com/casz)
+* [Justin](https://github.com/justinharringa)
 
 External Support:
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestTrigger.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestTrigger.java
@@ -1,0 +1,92 @@
+package io.jenkins.plugins.gitlabbranchsource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.scm.api.SCMHeadObserver;
+import org.gitlab4j.api.webhook.MergeRequestEvent;
+import org.gitlab4j.api.webhook.MergeRequestEvent.ObjectAttributes;
+
+public class GitLabMergeRequestTrigger extends GitLabMergeRequestSCMEvent {
+
+    public static final Logger LOGGER = Logger
+        .getLogger(GitLabMergeRequestTrigger.class.getName());
+
+    public GitLabMergeRequestTrigger(MergeRequestEvent mrEvent, String origin) {
+        super(mrEvent, origin);
+    }
+
+    @Override
+    public boolean isMatch(@NonNull GitLabSCMSource source) {
+        final GitLabSCMSourceContext sourceContext = new GitLabSCMSourceContext(
+            null, SCMHeadObserver.none())
+            .withTraits(source.getTraits());
+
+        boolean shouldBuild = this.shouldBuild(getPayload(), sourceContext);
+        LOGGER.log(Level.FINE, "isMatch() result for MR-{0}: {1}",
+            new Object[]{
+                getPayload().getObjectAttributes().getIid(),
+                String.valueOf(shouldBuild)
+            });
+
+        return getPayload().getObjectAttributes().getTargetProjectId()
+            .equals(source.getProjectId()) && shouldBuild;
+    }
+
+    private boolean shouldBuild(MergeRequestEvent mrEvent, GitLabSCMSourceContext context) {
+        ObjectAttributes attributes = mrEvent.getObjectAttributes();
+        String action = attributes.getAction();
+        boolean shouldBuild = true;
+
+        if (action != null) {
+            if (action.equals("update") && context.alwaysIgnoreNonCodeRelatedUpdates()) {
+                if (mrEvent.getChanges().getAssignees() != null) {
+                    shouldBuild = false;
+                }
+
+                if (mrEvent.getChanges().getDescription() != null) {
+                    shouldBuild = false;
+                }
+
+                if (mrEvent.getChanges().getMilestoneId() != null) {
+                    shouldBuild = false;
+                }
+
+                if (mrEvent.getChanges().getTitle() != null) {
+                    shouldBuild = false;
+                }
+
+                if (mrEvent.getChanges().getTotalTimeSpent() != null) {
+                    shouldBuild = false;
+                }
+
+                if (mrEvent.getChanges().getLabels() != null) {
+                    shouldBuild = false;
+                }
+            }
+
+            if (!shouldBuild) {
+                LOGGER.log(Level.FINE, "shouldBuild for MR-{0} set to false due to non-code related updates.",
+                    getPayload().getObjectAttributes().getIid());
+            }
+
+            if (action.equals("open")) {
+                return context.alwaysBuildMROpen();
+            }
+
+            if (action.equals("reopen")) {
+                return context.alwaysBuildMRReOpen();
+            }
+
+            if (action.equals("approved")) {
+                return !context.alwaysIgnoreMRApprove();
+            }
+
+            if (action.equals("unapproved")) {
+                return !context.alwaysIgnoreMRUnApprove();
+            }
+        }
+
+        return shouldBuild;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -899,7 +899,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     new BranchDiscoveryTrait(true, false),
                     new OriginMergeRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE)),
                     new ForkMergeRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE),
-                            new ForkMergeRequestDiscoveryTrait.TrustPermission()));
+                        new ForkMergeRequestDiscoveryTrait.TrustPermission()),
+                    new WebhookListenerBuildConditionsTrait(true, true, false, false, false));
         }
 
         @NonNull

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceContext.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceContext.java
@@ -49,6 +49,16 @@ public class GitLabSCMSourceContext
 
     private String buildStatusNameCustomPart = "";
 
+    private boolean alwaysBuildMROpen = true;
+
+    private boolean alwaysBuildMRReOpen = true;
+
+    private boolean alwaysIgnoreMRApprove = false;
+
+    private boolean alwaysIgnoreMRUnApprove = false;
+
+    private boolean alwaysIgnoreNonCodeRelatedUpdates = false;
+
     public GitLabSCMSourceContext(@CheckForNull SCMSourceCriteria criteria,
         @NonNull SCMHeadObserver observer) {
         super(criteria, observer);
@@ -119,6 +129,26 @@ public class GitLabSCMSourceContext
     }
 
     public final boolean getOnlyTrustedMembersCanTrigger() { return onlyTrustedMembersCanTrigger; }
+
+    public boolean alwaysBuildMROpen() {
+        return alwaysBuildMROpen;
+    }
+
+    public boolean alwaysBuildMRReOpen() {
+        return alwaysBuildMRReOpen;
+    }
+
+    public boolean alwaysIgnoreMRApprove() {
+        return alwaysIgnoreMRApprove;
+    }
+
+    public boolean alwaysIgnoreMRUnApprove() {
+        return alwaysIgnoreMRUnApprove;
+    }
+
+    public boolean alwaysIgnoreNonCodeRelatedUpdates() {
+        return alwaysIgnoreNonCodeRelatedUpdates;
+    }
 
     public final String getCommentBody() {
         return commentBody;
@@ -234,5 +264,30 @@ public class GitLabSCMSourceContext
     public GitLabSCMSourceRequest newRequest(@NonNull SCMSource source,
         @CheckForNull TaskListener listener) {
         return new GitLabSCMSourceRequest(source, this, listener);
+    }
+
+    public final GitLabSCMSourceContext withAlwaysBuildMROpen(boolean enabled) {
+        this.alwaysBuildMROpen = enabled;
+        return this;
+    }
+
+    public final GitLabSCMSourceContext withAlwaysBuildMRReOpen(boolean enabled) {
+        this.alwaysBuildMRReOpen = enabled;
+        return this;
+    }
+
+    public final GitLabSCMSourceContext withAlwaysIgnoreMRApprove(boolean enabled) {
+        this.alwaysIgnoreMRApprove = enabled;
+        return this;
+    }
+
+    public final GitLabSCMSourceContext withAlwaysIgnoreMRUnApprove(boolean enabled) {
+        this.alwaysIgnoreMRUnApprove = enabled;
+        return this;
+    }
+
+    public final GitLabSCMSourceContext withAlwaysIgnoreNonCodeRelatedUpdates(boolean enabled) {
+        this.alwaysIgnoreNonCodeRelatedUpdates = enabled;
+        return this;
     }
 }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebHookListener.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebHookListener.java
@@ -40,7 +40,7 @@ public class GitLabWebHookListener implements WebHookListener {
     public void onMergeRequestEvent(MergeRequestEvent mrEvent) {
         LOGGER.log(Level.FINE, mrEvent.toString());
         final long triggerDelay = findTriggerDelay(mrEvent.getProject().getWebUrl());
-        GitLabMergeRequestSCMEvent trigger = new GitLabMergeRequestSCMEvent(mrEvent, origin);
+        GitLabMergeRequestTrigger trigger = new GitLabMergeRequestTrigger(mrEvent, origin);
         SCMHeadEvent.fireLater(trigger, triggerDelay, TimeUnit.SECONDS);
     }
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/WebhookListenerBuildConditionsTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/WebhookListenerBuildConditionsTrait.java
@@ -1,0 +1,132 @@
+package io.jenkins.plugins.gitlabbranchsource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class WebhookListenerBuildConditionsTrait extends SCMSourceTrait {
+
+    /**
+     * Always fire build trigger on MR Open event
+     */
+    private boolean alwaysBuildMROpen = true;
+
+    /**
+     * Always fire build trigger on MR Re-Open event
+     */
+    private boolean alwaysBuildMRReOpen = true;
+
+    /**
+     * Always ignore webhook if it's an approval event
+     */
+    private boolean alwaysIgnoreMRApprove = false;
+
+    /**
+     * Always ignore webhook if it's an un-approval event
+     */
+    private boolean alwaysIgnoreMRUnApprove = false;
+
+    /**
+     * Always ignore webhook if it's a non code related update such as title change
+     */
+    private boolean alwaysIgnoreNonCodeRelatedUpdates = false;
+
+    /**
+     * Constructor for stapler.
+     */
+    @DataBoundConstructor
+    public WebhookListenerBuildConditionsTrait(boolean alwaysBuildMROpen, boolean alwaysBuildMRReOpen, boolean alwaysIgnoreMRApprove, boolean alwaysIgnoreMRUnApprove, boolean alwaysIgnoreNonCodeRelatedUpdates) {
+        this.alwaysBuildMROpen = alwaysBuildMROpen;
+        this.alwaysBuildMRReOpen = alwaysBuildMRReOpen;
+        this.alwaysIgnoreMRApprove = alwaysIgnoreMRApprove;
+        this.alwaysIgnoreMRUnApprove = alwaysIgnoreMRUnApprove;
+        this.alwaysIgnoreNonCodeRelatedUpdates = alwaysIgnoreNonCodeRelatedUpdates;
+    }
+
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        if (context instanceof GitLabSCMSourceContext) {
+            GitLabSCMSourceContext ctx = (GitLabSCMSourceContext) context;
+            ctx.withAlwaysBuildMROpen(getAlwaysBuildMROpen())
+                .withAlwaysBuildMRReOpen(getAlwaysBuildMRReOpen())
+                .withAlwaysIgnoreMRApprove(getAlwaysIgnoreMRApprove())
+                .withAlwaysIgnoreMRUnApprove(getAlwaysIgnoreMRUnApprove())
+                .withAlwaysIgnoreNonCodeRelatedUpdates(getAlwaysIgnoreNonCodeRelatedUpdates());
+        }
+    }
+
+    /**
+     * Our descriptor.
+     */
+    @Extension
+    @Symbol("WebhookListenerBuildConditionsTrait")
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return Messages.WebhookListenerBuildConditionsTrait_displayName();
+        }
+
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return GitLabSCMSourceContext.class;
+        }
+
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return GitLabSCMSource.class;
+        }
+    }
+
+    /**
+     * Run build on MR open
+     *
+     * @return true to fire trigger on MR Open
+     */
+    public boolean getAlwaysBuildMROpen() {
+        return alwaysBuildMROpen;
+    }
+
+    /**
+     * Run build on MR re-open
+     *
+     * @return true to fire trigger on MR Re-Open
+     */
+    public boolean getAlwaysBuildMRReOpen() {
+        return alwaysBuildMRReOpen;
+    }
+
+    /**
+     * Run build on MR approval
+     *
+     * @return false to run build on MR approval
+     */
+    public boolean getAlwaysIgnoreMRApprove() {
+        return alwaysIgnoreMRApprove;
+    }
+
+    /**
+     * Run build on MR un-approval
+     *
+     * @return false to run build on non-code related MR updates
+     */
+    public boolean getAlwaysIgnoreMRUnApprove() {
+        return alwaysIgnoreMRUnApprove;
+    }
+
+    /**
+     * Run build on MR non-code related updates e.g. MR title update
+     *
+     * @return false to run build on non-code related MR updates
+     */
+    public boolean getAlwaysIgnoreNonCodeRelatedUpdates() {
+        return alwaysIgnoreNonCodeRelatedUpdates;
+    }
+
+}

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
@@ -56,3 +56,4 @@ TriggerMRCommentTrait.displayName=Trigger build on merge request comment
 GitLabWebHookCause.ShortDescription.Push_noUser=Started by GitLab push
 GitLabWebHookCause.ShortDescription.Push=Started by GitLab push by {0}
 GitLabWebHookCause.ShortDescription.MergeRequestHook=Triggered by GitLab Merge Request #{0}: {1} => {2}
+WebhookListenerBuildConditionsTrait.displayName=Webhook Listener Conditions

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/WebhookListenerBuildConditionsTrait/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/WebhookListenerBuildConditionsTrait/config.jelly
@@ -1,0 +1,18 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="${%Always build pipeline on Open MR webhook}" field="alwaysBuildMROpen">
+    <f:checkbox default="checked"/>
+  </f:entry>
+  <f:entry title="${%Always build pipeline on Re-Open MR webhook}" field="alwaysBuildMRReOpen">
+    <f:checkbox default="checked"/>
+  </f:entry>
+  <f:entry title="${%Ignore build pipeline on MR Approval}" field="alwaysIgnoreMRApprove">
+    <f:checkbox default="checked"/>
+  </f:entry>
+  <f:entry title="${%Ignore build pipeline on MR Un-Approval}" field="alwaysIgnoreMRUnApprove">
+    <f:checkbox default="checked"/>
+  </f:entry>
+  <f:entry title="${%Ignore builds for non-code related MR updates}" field="alwaysIgnoreNonCodeRelatedUpdates">
+    <f:checkbox default="checked"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/WebhookListenerBuildConditionsTrait/help-alwaysIgnoreNonCodeRelatedUpdates.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/WebhookListenerBuildConditionsTrait/help-alwaysIgnoreNonCodeRelatedUpdates.html
@@ -1,0 +1,5 @@
+<div>
+  GitLab will send a webhook to Jenkins when there are updates to the MR including title changes, labels removed/added, etc. Enabling this option will prevent a build running if the cause was one of these updates.
+
+  Note: these settings do not have any impact on build from comment settings.
+</div>


### PR DESCRIPTION
Currently the plugin is building whenever a merge request is updated. For example if the title of the MR is updated, if it is approved, etc.

This is causing huge frustration for our developers as the pipeline can be restarted many many times when doing admin on the MR like adding labels etc.

This PR adds the following options:

![image](https://user-images.githubusercontent.com/7827942/132270487-25c1fcb1-4906-4d6c-9d48-ecf6b21777ab.png)

which when set to true enable skipping the build on such events as MR approved/unapproved and other changes like MR title update

![image](https://user-images.githubusercontent.com/7827942/132270539-3aaa025c-b725-4d2e-b477-640728980ea9.png)


