### PR TITLE
118 exclude archived projects

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/ExcludeArchivedRepositoriesTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/ExcludeArchivedRepositoriesTrait.java
@@ -1,0 +1,47 @@
+package io.jenkins.plugins.gitlabbranchsource;
+
+import hudson.Extension;
+import javax.annotation.Nonnull;
+import jenkins.scm.api.trait.SCMNavigatorContext;
+import jenkins.scm.api.trait.SCMNavigatorTrait;
+import jenkins.scm.api.trait.SCMNavigatorTraitDescriptor;
+import jenkins.scm.impl.trait.Selection;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * A {@link Selection} trait that will restrict the discovery of repositories that have been
+ * archived.
+ */
+public class ExcludeArchivedRepositoriesTrait extends SCMNavigatorTrait {
+
+    /** Constructor for stapler. */
+    @DataBoundConstructor
+    public ExcludeArchivedRepositoriesTrait() {}
+
+    /** {@inheritDoc} */
+    @Override
+    protected void decorateContext(SCMNavigatorContext<?, ?> context) {
+        super.decorateContext(context);
+        GitLabSCMNavigatorContext ctx = (GitLabSCMNavigatorContext) context;
+        ctx.setExcludeArchivedRepositories(true);
+    }
+
+    /** Exclude archived repositories filter */
+    @Symbol("gitLabExcludeArchivedRepositories")
+    @Extension
+    @Selection
+    public static class DescriptorImpl extends SCMNavigatorTraitDescriptor {
+
+        @Override
+        public Class<? extends SCMNavigatorContext> getContextClass() {
+            return GitLabSCMNavigatorContext.class;
+        }
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return Messages.ExcludeArchivedRepositoriesTrait_displayName();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -224,9 +224,9 @@ public class GitLabSCMNavigator extends SCMNavigator {
     @Override
     public void visitSources(@NonNull final SCMSourceObserver observer)
         throws IOException, InterruptedException {
-        try (GitLabSCMNavigatorRequest request = new GitLabSCMNavigatorContext()
-            .withTraits(traits)
-            .newRequest(this, observer)) {
+        GitLabSCMNavigatorContext context = new GitLabSCMNavigatorContext()
+            .withTraits(traits);
+        try (GitLabSCMNavigatorRequest request = context.newRequest(this, observer)) {
             GitLabApi gitLabApi = apiBuilder(serverName);
             getGitlabOwner(gitLabApi);
             List<Project> projects;
@@ -263,6 +263,12 @@ public class GitLabSCMNavigator extends SCMNavigator {
                 if (StringUtils.isEmpty(p.getDefaultBranch())) {
                     observer.getListener().getLogger()
                         .format("%nIgnoring project with empty repository %s%n",
+                            HyperlinkNote.encodeTo(p.getWebUrl(), p.getName()));
+                    continue;
+                }
+                if (p.getArchived() && context.isExcludeArchivedRepositories()) {
+                    observer.getListener().getLogger()
+                        .format("%nIgnoring archived project %s%n",
                             HyperlinkNote.encodeTo(p.getWebUrl(), p.getName()));
                     continue;
                 }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigatorContext.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigatorContext.java
@@ -12,6 +12,9 @@ public class GitLabSCMNavigatorContext extends
 
     private int projectNamingStrategy = 1;
 
+    /** If true, archived repositories will be ignored. */
+    private boolean excludeArchivedRepositories;
+
     @NonNull
     @Override
     public GitLabSCMNavigatorRequest newRequest(@NonNull SCMNavigator navigator,
@@ -43,5 +46,15 @@ public class GitLabSCMNavigatorContext extends
     public GitLabSCMNavigatorContext withProjectNamingStrategy(int strategyId) {
         this.projectNamingStrategy = strategyId;
         return this;
+    }
+
+    /** @return True if archived repositories should be ignored, false if they should be included. */
+    public boolean isExcludeArchivedRepositories() {
+        return excludeArchivedRepositories;
+    }
+
+    /** @param excludeArchivedRepositories Set true to exclude archived repositories */
+    public void setExcludeArchivedRepositories(boolean excludeArchivedRepositories) {
+        this.excludeArchivedRepositories = excludeArchivedRepositories;
     }
 }

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ExcludeArchivedTrait/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ExcludeArchivedTrait/config.jelly
@@ -1,0 +1,5 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:c="/lib/credentials"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:f2="/org/jenkinsci/plugins/gitlab_branch_source/form">
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ExcludeArchivedTrait/help.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/ExcludeArchivedTrait/help.html
@@ -1,0 +1,3 @@
+<div>
+  Exclude GitLab repositories that have been archived. If set, no jobs will be created for archived repositories.
+</div>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
@@ -4,6 +4,7 @@ BranchDiscoveryTrait.authorityDisplayName=Trust origin branches
 BranchDiscoveryTrait.displayName=Discover branches
 BranchDiscoveryTrait.excludeMRs=Only branches that are not also filed as MRs
 BranchDiscoveryTrait.onlyMRs=Only branches that are also filed as MRs
+ExcludeArchivedRepositoriesTrait.displayName=Exclude archived repositories
 BuildStatusNameCustomPartTrait.displayName=Customize GitLab build status name
 ForkMergeRequestDiscoveryTrait.displayName=Discover merge requests from forks
 ForkMergeRequestDiscoveryTrait.headAndMerge=Both the current merge request revision and the merge request merged with \


### PR DESCRIPTION
Following the example for the GitHub Plugin (linked in discussion) this PR adds the configuration option to exclude archived projects from the list of projects that are built by jenkins. Posthum archived projects are removed from the project list on the next scan.

https://github.com/jenkinsci/gitlab-branch-source-plugin/issues/118
https://issues.jenkins.io/browse/JENKINS-63610

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
-> There are no unit tests for GitLabSCMNavigator to begin with, to use as orientation. The fix was integration-tested on a local Jenkins instance.