### PR TITLE
support extracting MR id when using both strategy

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
@@ -33,7 +33,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import jenkins.plugins.git.GitTagSCMRevision;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
@@ -60,7 +59,7 @@ public class GitLabPipelineStatusNotifier {
     static final String GITLAB_PIPELINE_STATUS_PREFIX = "jenkinsci";
 
     static final String GITLAB_PIPELINE_STATUS_DELIMITER = "/";
-    
+
     static final Pattern MERGE_REQUEST_JOB_NAME_FORMAT = Pattern.compile("MR-(\\d+)(|-(merge|head))");
 
     private static String getRootUrl(Run<?, ?> build) {
@@ -216,11 +215,11 @@ public class GitLabPipelineStatusNotifier {
         LOGGER.log(Level.INFO, "Getting source project ID from MR");
         Matcher m = MERGE_REQUEST_JOB_NAME_FORMAT.matcher(job.getName());
         if (!m.matches()) {
-            LOGGER.log(Level.WARNING, String.format("Job name does not match expected format: [%s], [%s]", job.getName(), 
+            LOGGER.log(Level.WARNING, String.format("Job name does not match expected format: [%s], [%s]", job.getName(),
                     MERGE_REQUEST_JOB_NAME_FORMAT.pattern()));
             return null;
         }
-        
+
         Integer mrId = Integer.parseInt(m.group(1));
         MergeRequest mr;
         try {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
@@ -61,7 +61,7 @@ public class GitLabPipelineStatusNotifier {
 
     static final String GITLAB_PIPELINE_STATUS_DELIMITER = "/";
     
-    static final Pattern MERGE_REQUEST_PROJECT_NAME_FORMAT = Pattern.compile("MR-(\\d+)(|-(merge|head))");
+    static final Pattern MERGE_REQUEST_JOB_NAME_FORMAT = Pattern.compile("MR-(\\d+)(|-(merge|head))");
 
     private static String getRootUrl(Run<?, ?> build) {
         try {
@@ -214,10 +214,10 @@ public class GitLabPipelineStatusNotifier {
      */
     static Integer getSourceProjectId(Job job, GitLabApi gitLabApi, String projectPath) {
         LOGGER.log(Level.INFO, "Getting source project ID from MR");
-        Matcher m = MERGE_REQUEST_PROJECT_NAME_FORMAT.matcher(job.getName());
+        Matcher m = MERGE_REQUEST_JOB_NAME_FORMAT.matcher(job.getName());
         if (!m.matches()) {
             LOGGER.log(Level.WARNING, String.format("Job name does not match expected format: [%s], [%s]", job.getName(), 
-                    MERGE_REQUEST_PROJECT_NAME_FORMAT.pattern()));
+                    MERGE_REQUEST_JOB_NAME_FORMAT.pattern()));
             return null;
         }
         

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifierTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifierTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.gitlabbranchsource.helpers;
 
+import hudson.model.FreeStyleProject;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
 import io.jenkins.plugins.gitlabbranchsource.BranchSCMHead;
 import io.jenkins.plugins.gitlabbranchsource.BranchSCMRevision;
 import io.jenkins.plugins.gitlabbranchsource.GitLabSCMSourceContext;
@@ -8,10 +11,16 @@ import io.jenkins.plugins.gitlabbranchsource.MergeRequestSCMRevision;
 import jenkins.plugins.git.GitTagSCMHead;
 import jenkins.plugins.git.GitTagSCMRevision;
 import jenkins.scm.api.SCMRevision;
+import org.gitlab4j.api.GitLabApi;
+import org.gitlab4j.api.MergeRequestApi;
+import org.gitlab4j.api.models.MergeRequest;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 public class GitLabPipelineStatusNotifierTest {
 
@@ -116,6 +125,75 @@ public class GitLabPipelineStatusNotifierTest {
         String refName = GitLabPipelineStatusNotifier.getRevisionRef(revision);
 
         assertThat(refName, is(tagName));
+    }
+
+    @Test
+    public void should_get_mr_project_id() throws Exception {
+        String projectPath = "project_path";
+        Integer projectId = Integer.valueOf(100);
+
+        ItemGroup<?> parent = Mockito.mock(ItemGroup.class);
+        Mockito.when(parent.getFullName()).thenReturn("folder/project");
+
+        Job<?,?> job = new FreeStyleProject(parent, "MR-123");
+
+        GitLabApi gitLabApi = Mockito.mock(GitLabApi.class);
+        MergeRequestApi mrApi = Mockito.mock(MergeRequestApi.class);
+        MergeRequest mr = Mockito.mock(MergeRequest.class);
+
+        Mockito.when(gitLabApi.getMergeRequestApi()).thenReturn(mrApi);
+        Mockito.when(mrApi.getMergeRequest(any(), eq(Integer.valueOf(123)))).thenReturn(mr);
+        Mockito.when(mr.getSourceProjectId()).thenReturn(projectId);
+
+        Integer sourceProjectId = GitLabPipelineStatusNotifier.getSourceProjectId(job, gitLabApi, projectPath);
+
+        assertThat(sourceProjectId, is(projectId));
+    }
+
+    @Test
+    public void should_get_mr_project_id_projects_using_both_strategy_head() throws Exception {
+        String projectPath = "project_path";
+        Integer projectId = Integer.valueOf(100);
+
+        ItemGroup<?> parent = Mockito.mock(ItemGroup.class);
+        Mockito.when(parent.getFullName()).thenReturn("folder/project");
+
+        Job<?,?> job = new FreeStyleProject(parent, "MR-123-head");
+
+        GitLabApi gitLabApi = Mockito.mock(GitLabApi.class);
+        MergeRequestApi mrApi = Mockito.mock(MergeRequestApi.class);
+        MergeRequest mr = Mockito.mock(MergeRequest.class);
+
+        Mockito.when(gitLabApi.getMergeRequestApi()).thenReturn(mrApi);
+        Mockito.when(mrApi.getMergeRequest(any(), eq(Integer.valueOf(123)))).thenReturn(mr);
+        Mockito.when(mr.getSourceProjectId()).thenReturn(projectId);
+
+        Integer sourceProjectId = GitLabPipelineStatusNotifier.getSourceProjectId(job, gitLabApi, projectPath);
+
+        assertThat(sourceProjectId, is(projectId));
+    }
+
+    @Test
+    public void should_get_mr_project_id_projects_using_both_strategy_merge() throws Exception {
+        String projectPath = "project_path";
+        Integer projectId = Integer.valueOf(100);
+
+        ItemGroup<?> parent = Mockito.mock(ItemGroup.class);
+        Mockito.when(parent.getFullName()).thenReturn("folder/project");
+
+        Job<?,?> job = new FreeStyleProject(parent, "MR-123-merge");
+
+        GitLabApi gitLabApi = Mockito.mock(GitLabApi.class);
+        MergeRequestApi mrApi = Mockito.mock(MergeRequestApi.class);
+        MergeRequest mr = Mockito.mock(MergeRequest.class);
+
+        Mockito.when(gitLabApi.getMergeRequestApi()).thenReturn(mrApi);
+        Mockito.when(mrApi.getMergeRequest(any(), eq(Integer.valueOf(123)))).thenReturn(mr);
+        Mockito.when(mr.getSourceProjectId()).thenReturn(projectId);
+
+        Integer sourceProjectId = GitLabPipelineStatusNotifier.getSourceProjectId(job, gitLabApi, projectPath);
+
+        assertThat(sourceProjectId, is(projectId));
     }
 
 }


### PR DESCRIPTION
Fixes #164

Overrides #165


@jetersen 

I never liked the split either but I thought I'd stick with what was there.
Let me know if this is more to your liking.

I'll install it on our test jenkins instance to make sure it works as expected (can't remember if there was another issue and that's why I had that logic to revert to using the project name instead of the id in my other PR).

