### PR TITLE
option to poll gitlab immediately on a web hook trigger

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -332,7 +332,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     /**
      * Data Bound Setter for immediate build on a GitLab Web Hook trigger.
      *
-     * @param manageSystemHooks {@code true} if and only if Jenkins should trigger a build immediately on a
+     * @param immediateHookTrigger {@code true} if and only if Jenkins should trigger a build immediately on a
      * GitLab Web Hook trigger.
      */
     @DataBoundSetter

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -127,6 +127,12 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     private Secret secretToken;
 
     /**
+     * {@code true} if and only if Jenkins should trigger a build immediately on a
+     * GitLab Web Hook trigger.
+     */
+    private boolean immediateHookTrigger;
+
+    /**
      * Delay to be used for GitLab Web Hook build triggers.
      */
     private Integer hookTriggerDelay;
@@ -310,6 +316,28 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
             return null;
         }
         return this.secretToken.getPlainText();
+    }
+
+    /**
+     * Returns {@code true} if Jenkins should trigger a build immediately on a
+     * GitLab Web Hook trigger.
+     *
+     * @return {@code true} if Jenkins should trigger a build immediately on a
+     * GitLab Web Hook trigger.
+     */
+    public boolean isImmediateHookTrigger() {
+        return immediateHookTrigger;
+    }
+
+    /**
+     * Data Bound Setter for immediate build on a GitLab Web Hook trigger.
+     *
+     * @param manageSystemHooks {@code true} if and only if Jenkins should trigger a build immediately on a
+     * GitLab Web Hook trigger.
+     */
+    @DataBoundSetter
+    public void setImmediateHookTrigger(boolean immediateHookTrigger) {
+        this.immediateHookTrigger = immediateHookTrigger;
     }
 
     /**

--- a/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/config.groovy
+++ b/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/config.groovy
@@ -37,6 +37,9 @@ f.entry(title: _("Root URL for hooks"), field: "hooksRootUrl", "description": "J
 }
 
 f.advanced() {
+    f.entry(title: _("Immediate Web Hook trigger"), field: "immediateHookTrigger", "description": "Trigger a build immediately on a GitLab Web Hook trigger") {
+        f.checkbox(title: _("Immediate Web Hook trigger"))
+    }
     f.entry(title: _("Web Hook trigger delay"), field: "hookTriggerDelay", "description": "Delay in seconds to be used for GitLab Web Hook build triggers (defaults to GitLab cache timeout)") {
         f.textbox()
     }

--- a/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/help-immediateHookTrigger.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/help-immediateHookTrigger.html
@@ -1,0 +1,6 @@
+<div>
+  Select this option if you want to immediately query gitlab for modifications when a 
+  web hook trigger is received.
+  Using this option lets you start a build a soon as possible and rely on the "Web Hook trigger delay"
+  value as a fallback in case gitlab's cache did not return the modifications. 
+</div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Since version `1.5.9` there is now an option to set a delay (defaults to 30 seconds) when a gitlab web hook triggers a build to make sure jenkins does not hit the gitlab cache.

Our users started complaining with the longer delay, so we set it to 0 which is fine 98% of the time with our self hosted gitlab server. However it is true that sometimes changes are not detected and then it can take hours before jenkins detects a change (we configure our projects to poll every 4 hours just in case).

So I intoduced a checkbox to have the option of `Immediate Web Hook trigger`: poll gitlab as soon as the web hook trigger is received and also poll gitlab a second time after the delay.

Best case scenario:
1. Immediate poll sees modifications and starts a build.
2. Delayed poll sees no new modificiations (same commit as current/last build)

Worst case scenario:
1. Immediate poll hits the gitlab cache and does not see modifications.
2. Delayed poll sees the modifications and starts the build.

![image](https://user-images.githubusercontent.com/595214/164042584-41279a9d-a85e-4c74-9dd7-8378be7f5026.png)


Let me know what you think, especially the wording on the configuration page to make sure it is not confusing.

Thanks