### PR TITLE
Bump plugin BOM from 1280.vd669827e38cd to 1289.v5c4b_1c43511b_

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>gitlab-api</artifactId>
-      <version>5.0.1-69.vcdc19e779072</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -49,7 +48,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>handy-uri-templates-2-api</artifactId>
-      <version>2.1.8-1.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -139,7 +137,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.289.x</artifactId>
-        <version>1280.vd669827e38cd</version>
+        <version>1289.v5c4b_1c43511b_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
Cleaning up after #188. Now that jenkinsci/bom#1020 has been merged and released, we don't need to specify a custom version for `gitlab-api` or `handy-uri-templates-2-api` anymore. Instead we can take these versions from the BOM.

This is just a cleanup; there is no urgent need for this to be released.

CC @jetersen