### PR TITLE
#207: allowing also 27 chars as token size

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/credentials/PersonalAccessTokenImpl.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/credentials/PersonalAccessTokenImpl.java
@@ -65,7 +65,8 @@ public class PersonalAccessTokenImpl extends BaseStandardCredentials implements
     @Symbol("gitlabPersonalAccessToken")
     public static class DescriptorImpl extends CredentialsDescriptor {
 
-        private static final int GITLAB_ACCESS_TOKEN_LENGTH = 20;
+        private static final int GITLAB_ACCESS_TOKEN_LENGTH_LEGACY = 20;
+        private static final int GITLAB_ACCESS_TOKEN_LENGTH = 26;
 
         /**
          * {@inheritDoc}
@@ -87,11 +88,11 @@ public class PersonalAccessTokenImpl extends BaseStandardCredentials implements
         public FormValidation doCheckToken(@QueryParameter String value) {
             Secret secret = Secret.fromString(value);
             if (StringUtils.equals(value, secret.getPlainText())) {
-                if (value.length() != GITLAB_ACCESS_TOKEN_LENGTH) {
+                if (value.length() != GITLAB_ACCESS_TOKEN_LENGTH && value.length() != GITLAB_ACCESS_TOKEN_LENGTH_LEGACY) {
                     return FormValidation
                         .error(Messages.PersonalAccessTokenImpl_tokenWrongLength());
                 }
-            } else if (secret.getPlainText().length() != GITLAB_ACCESS_TOKEN_LENGTH) {
+            } else if (secret.getPlainText().length() != GITLAB_ACCESS_TOKEN_LENGTH && value.length() != GITLAB_ACCESS_TOKEN_LENGTH_LEGACY) {
                 return FormValidation.error(Messages.PersonalAccessTokenImpl_tokenWrongLength());
             }
             return FormValidation.ok();

--- a/src/main/resources/io/jenkins/plugins/gitlabserverconfig/credentials/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabserverconfig/credentials/Messages.properties
@@ -1,3 +1,3 @@
 PersonalAccessTokenImpl.displayName=GitLab Personal Access Token
 PersonalAccessTokenImpl.tokenRequired=Token required
-PersonalAccessTokenImpl.tokenWrongLength=Token should be 20 characters long
+PersonalAccessTokenImpl.tokenWrongLength=Token should be 20 or 26 characters long


### PR DESCRIPTION
### Fixing #207 : PAT length now 27 

Adding 27 chars as possibility for PAT size. I did not remove the check against 20 chars because of backward compatibility against legacy gitlab-installations. Should fix #207 .

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
