### PR TITLE
Allowing the gitlab token to be 20 characters or more

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ credentials:
           - gitlabPersonalAccessToken:
               scope: SYSTEM
               id: "i<3GitLab"
-              token: "XfsqZvVtAx5YCph5bq3r" # gitlab personal access token
+              token: "glpat-XfsqZvVtAx5YCph5bq3r" # gitlab personal access token
 
 unclassified:
   gitLabServers:

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/credentials/PersonalAccessTokenImpl.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/credentials/PersonalAccessTokenImpl.java
@@ -65,7 +65,7 @@ public class PersonalAccessTokenImpl extends BaseStandardCredentials implements
     @Symbol("gitlabPersonalAccessToken")
     public static class DescriptorImpl extends CredentialsDescriptor {
 
-        private static final int GITLAB_ACCESS_TOKEN_LENGTH = 20;
+        private static final int GITLAB_ACCESS_TOKEN_MINIMAL_LENGTH = 20;
 
         /**
          * {@inheritDoc}
@@ -87,11 +87,11 @@ public class PersonalAccessTokenImpl extends BaseStandardCredentials implements
         public FormValidation doCheckToken(@QueryParameter String value) {
             Secret secret = Secret.fromString(value);
             if (StringUtils.equals(value, secret.getPlainText())) {
-                if (value.length() != GITLAB_ACCESS_TOKEN_LENGTH) {
+                if (value.length() < GITLAB_ACCESS_TOKEN_MINIMAL_LENGTH) {
                     return FormValidation
                         .error(Messages.PersonalAccessTokenImpl_tokenWrongLength());
                 }
-            } else if (secret.getPlainText().length() != GITLAB_ACCESS_TOKEN_LENGTH) {
+            } else if (secret.getPlainText().length() < GITLAB_ACCESS_TOKEN_MINIMAL_LENGTH) {
                 return FormValidation.error(Messages.PersonalAccessTokenImpl_tokenWrongLength());
             }
             return FormValidation.ok();

--- a/src/main/resources/io/jenkins/plugins/gitlabserverconfig/credentials/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabserverconfig/credentials/Messages.properties
@@ -1,3 +1,3 @@
 PersonalAccessTokenImpl.displayName=GitLab Personal Access Token
 PersonalAccessTokenImpl.tokenRequired=Token required
-PersonalAccessTokenImpl.tokenWrongLength=Token should be 20 characters long
+PersonalAccessTokenImpl.tokenWrongLength=Token should be at least 20 characters long

--- a/src/test/java/io/jenkins/plugins/gitlabserverconfig/casc/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabserverconfig/casc/ConfigurationAsCodeTest.java
@@ -47,8 +47,8 @@ public class ConfigurationAsCodeTest {
         );
         assertThat(credentials, hasSize(1));
         final PersonalAccessTokenImpl credential = credentials.get(0);
-        assertThat(credential.getToken().getPlainText(), is("XfsqZvVtAx5YCph5bq3r"));
-        assertThat(credential.getToken().getEncryptedValue(), is(not("XfsqZvVtAx5YCph5bq3r")));
+        assertThat(credential.getToken().getPlainText(), is("glpat-XfsqZvVtAx5YCph5bq3r"));
+        assertThat(credential.getToken().getEncryptedValue(), is(not("glpat-XfsqZvVtAx5YCph5bq3r")));
     }
 
     @Test

--- a/src/test/resources/io/jenkins/plugins/gitlabserverconfig/casc/configuration-as-code.yml
+++ b/src/test/resources/io/jenkins/plugins/gitlabserverconfig/casc/configuration-as-code.yml
@@ -5,7 +5,7 @@ credentials:
           - gitlabPersonalAccessToken:
               scope: SYSTEM
               id: "i<3GitLab"
-              token: "XfsqZvVtAx5YCph5bq3r"
+              token: "glpat-XfsqZvVtAx5YCph5bq3r"
 
 unclassified:
   gitLabServers:


### PR DESCRIPTION
Fixes #207

As discussed in https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/210#issuecomment-1161360539, since the prefix can be `glpat-` or anything (from empty String to anything more) see https://docs.gitlab.com/ee/user/admin_area/settings/account_and_limit_settings.html#personal-access-token-prefix

The check should be changed to accept 20 characters or more.

I reworked commit proposed by @sebastiangraf (added as co-author of my commit) in https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/210

---

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
