### PR TITLE
Correction of issue using gitlab credential with system scope

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -11,8 +11,6 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
-import hudson.model.Item;
-import hudson.model.ItemGroup;
 import hudson.security.ACL;
 import hudson.security.AccessControlled;
 import hudson.util.FormValidation;

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -243,30 +243,15 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
         Jenkins jenkins = Jenkins.get();
         if (context == null) {
             jenkins.checkPermission(CredentialsProvider.USE_OWN);
-            return StringUtils.isBlank(credentialsId) ? null : CredentialsMatchers.firstOrNull( lookupCredentials(
+        } else {
+            context.checkPermission(CredentialsProvider.USE_OWN);
+        }
+        return StringUtils.isBlank(credentialsId) ? null : CredentialsMatchers.firstOrNull( lookupCredentials(
                                                                                                     PersonalAccessToken.class,
                                                                                                     jenkins,
                                                                                                     ACL.SYSTEM,
                                                                                                     fromUri(defaultIfBlank(serverUrl, GITLAB_SERVER_URL)).build()
                                                                                                 ), withId(credentialsId));
-        } else {
-            context.checkPermission(CredentialsProvider.USE_OWN);
-            if (context instanceof ItemGroup) {
-                return StringUtils.isBlank(credentialsId) ? null : CredentialsMatchers.firstOrNull( lookupCredentials(
-                    PersonalAccessToken.class,
-                    (ItemGroup) context,
-                    ACL.SYSTEM,
-                    fromUri(defaultIfBlank(serverUrl, GITLAB_SERVER_URL)).build()
-                ), withId(credentialsId));
-            } else {
-                return StringUtils.isBlank(credentialsId) ? null : CredentialsMatchers.firstOrNull( lookupCredentials(
-                    PersonalAccessToken.class,
-                    (Item) context,
-                    ACL.SYSTEM,
-                    fromUri(defaultIfBlank(serverUrl, GITLAB_SERVER_URL)).build()
-                ), withId(credentialsId));
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
Don't understand what that means
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

Context : tries to correct issue #221
I keep the most code of @mymarche  but in the function to get the gitlab credential.
I check the permission with the user (context parameters) but use the jenkins object to get the gitlab credential.

It seems the check is used to know if the user can have the access to the functionality when there is the job configuration or during the execution.

I'm not good enough to test it in code.

maven clean package works to have the hpi file.
Thanks to test the plugin with your test installation. 
Be careful, It's not production ready.
We'll test it in our test environment after this first test.

My test is inspired with the README in the plugin : 
Create a Jenkins  instance with the recommended plugins by Jenkins and install "Role-based Authorization Strategy" and the built version of gitlab branch source.
With admin user do these actions : 
Create 2 users: launcher  and editer 
![image](https://user-images.githubusercontent.com/6814217/186761387-011b70c8-61b1-4edb-bb40-75850513b0df.png)

Create 2 folders at the root : admin and user
![image](https://user-images.githubusercontent.com/6814217/186761542-cb24d950-b95c-4fd3-8c5d-5721d45f138f.png)

Configure the Role-based auth : 
![image](https://user-images.githubusercontent.com/6814217/186761706-b691874e-f6ff-4c3b-8e9e-2a48a62cb70a.png)
![image](https://user-images.githubusercontent.com/6814217/186761834-41c18122-58b3-4a83-a97e-84a271bbbf31.png)

Configure GItlab branch source : 
![image](https://user-images.githubusercontent.com/6814217/186762301-aeeaadf7-3346-4729-95b0-7892e71319dc.png)
The credential is in system scope.
![image](https://user-images.githubusercontent.com/6814217/186762472-ba181680-9474-49af-9b46-cd9af3994125.png)
> Sorry for the image but in the description, there are information from my gitlab account.

Connect with editer user and create job with gitlab project :
![configure_pipeline](https://user-images.githubusercontent.com/6814217/186763412-725fc438-2d9f-4e04-b622-fa6b9e739f46.png)
> Here too, I hide personal info

Connect with launcher user and execute the pipeline : 
Log of jenkinsfile : 
<details>
```
Started by user launcher
Querying the current revision of branch test_gitlab_branch_source...
Current revision of branch test_gitlab_branch_source is <sha1 commit>
Obtained Jenkinsfile from <sha1 commit>
[Pipeline] Start of Pipeline
[Pipeline] node
Running on Jenkins in /var/jenkins_home/workspace/source_test_gitlab_branch_source
[Pipeline] {
[Pipeline] stage
[Pipeline] { (Declarative: Checkout SCM)
[Pipeline] checkout
The recommended git tool is: NONE
using credential ddd3193d-0722-4ec2-9d95-be33e2c24953
 > git rev-parse --resolve-git-dir /var/jenkins_home/workspace/source_test_gitlab_branch_source/.git # timeout=10
Fetching changes from the remote Git repository
 > git config remote.origin.url https://gitlab.com/<myaccount>/<myproject>.git # timeout=10
Fetching without tags
Fetching upstream changes from https://gitlab.com/<myaccount>/<myproject>.git
 > git --version # timeout=10
 > git --version # 'git version 2.36.1'
using GIT_ASKPASS to set credentials Gitlab PAT to checkout
 > git fetch --no-tags --force --progress -- https://gitlab.com/<myaccount>/<myproject>.git +refs/heads/test_gitlab_branch_source:refs/remotes/origin/test_gitlab_branch_source # timeout=10
Checking out Revision <sha1 commit> (test_gitlab_branch_source)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f <sha1 commit> # timeout=10
Commit message: "ajout de Jenkinsfile pour  tester le plugin gitlab branch source"
 > git rev-list --no-walk <sha1 commit> # timeout=10
[GitLab Pipeline Status] Notifying branch build status: RUNNING user/test_gitlab_branch_source/test_gitlab_branch_source #2: Build started...
[GitLab Pipeline Status] Notified
[Pipeline] }
[Pipeline] // stage
[Pipeline] withEnv
[Pipeline] {
[Pipeline] stage
[Pipeline] { (Hello)
[Pipeline] echo
Hello World
[Pipeline] sh
+ ls -l
total 24
drwxr-xr-x 7 root root 4096 Aug 25 19:49 Cluster
-rw-r--r-- 1 root root  179 Aug 25 19:49 Jenkinsfile
-rw-r--r-- 1 root root  117 Aug 25 19:49 README.md
-rw-r--r-- 1 root root 3399 Aug 25 19:49 ivvReport.py
drwxr-xr-x 6 root root 4096 Aug 25 19:49 resources
drwxr-xr-x 2 root root 4096 Aug 25 19:49 templates
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
[GitLab Pipeline Status] Notifying branch build status: SUCCESS user/test_gitlab_branch_source/test_gitlab_branch_source #2: This commit looks good.
[GitLab Pipeline Status] Notified
Finished: SUCCESS
```
</details>

And the status is shown in Gitlab : 
![status_pipeline](https://user-images.githubusercontent.com/6814217/186764488-6e773b30-099f-413b-a395-cd199b48e6da.png)


Jenkins : 2.346.1

List of plugins :
<details>
```
SnakeYAML API Plugin (snakeyaml-api): 1.30.2-76.vc104f7ce9870
Authentication Tokens API Plugin (authentication-tokens): 1.4
Blue Ocean Core JS (blueocean-core-js): 1.25.5
bouncycastle API Plugin (bouncycastle-api): 2.25
Pipeline: Declarative (pipeline-model-definition): 2.2097.v33db_b_de764b_e
ECharts API Plugin (echarts-api): 5.3.3-1
Pipeline: Job (workflow-job): 1189.va_d37a_e9e4eda_
Jakarta Activation API (jakarta-activation-api): 2.0.1-1
i18n for Blue Ocean (blueocean-i18n): 1.25.5
Structs Plugin (structs): 318.va_f3ccb_729b_71
JavaMail API (javax-mail-api): 1.6.2-6
JWT for Blue Ocean (blueocean-jwt): 1.25.5
Pipeline: Nodes and Processes (workflow-durable-task-step): 1174.v73a_9a_17edce0
Pipeline: Build Step (pipeline-build-step): 2.18
Bitbucket Pipeline for Blue Ocean (blueocean-bitbucket-pipeline): 1.25.5
Pipeline: SCM Step (workflow-scm-step): 400.v6b_89a_1317c9a_
Git client plugin (git-client): 3.11.0
Pipeline: Multibranch (workflow-multibranch): 716.vc692a_e52371b_
GitHub Pipeline for Blue Ocean (blueocean-github-pipeline): 1.25.5
Popper.js 2 API Plugin (popper2-api): 2.11.5-2
Trilead API Plugin (trilead-api): 1.57.v6e90e07157e1
Email Extension Plugin (email-ext): 2.91
Folders Plugin (cloudbees-folder): 6.740.ve4f4ffa_dea_54
Pipeline (workflow-aggregator): 590.v6a_d052e5a_a_b_5
GitHub Branch Source Plugin (github-branch-source): 1687.v7618247e672d
Caffeine API Plugin (caffeine-api): 2.9.3-65.v6a_47d0f4d1fe
Handy Uri Templates 2.x API Plugin (handy-uri-templates-2-api): 2.1.8-22.v77d5b_75e6953
Pipeline: Milestone Step (pipeline-milestone-step): 101.vd572fef9d926
Bitbucket Branch Source Plugin (cloudbees-bitbucket-branch-source): 773.v4b_9b_005b_562b_
JUnit Plugin (junit): 1119.1121.vc43d0fc45561
Pipeline: Declarative Extension Points API (pipeline-model-extensions): 2.2097.v33db_b_de764b_e
Token Macro Plugin (token-macro): 293.v283932a_0a_b_49
Server Sent Events (SSE) Gateway Plugin (sse-gateway): 1.25
Pipeline SCM API for Blue Ocean (blueocean-pipeline-scm-api): 1.25.5
OWASP Markup Formatter Plugin (antisamy-markup-formatter): 2.7
Gitlab API Plugin (gitlab-api): 5.0.1-78.v47a_45b_9f78b_7
Plain Credentials Plugin (plain-credentials): 1.8
Dashboard for Blue Ocean (blueocean-dashboard): 1.25.5
PAM Authentication plugin (pam-auth): 1.10
Durable Task Plugin (durable-task): 496.va67c6f9eefa7
SSH Credentials Plugin (ssh-credentials): 277.v95c2fec1c047
Pipeline: Supporting APIs (workflow-support): 833.va_1c71061486b_
Pipeline Graph Analysis Plugin (pipeline-graph-analysis): 195.v5812d95a_a_2f9
Role-based Authorization Strategy (role-strategy): 561.v9846c7351a_41
REST Implementation for Blue Ocean (blueocean-rest-impl): 1.25.5
SSH Build Agents plugin (ssh-slaves): 1.821.vd834f8a_c390e
Pub-Sub "light" Bus (pubsub-light): 1.16
Credentials Binding Plugin (credentials-binding): 523.vd859a_4b_122e6
HTML Publisher plugin (htmlpublisher): 1.30
Bootstrap 5 API Plugin (bootstrap5-api): 5.1.3-7
JavaBeans Activation Framework (JAF) API (javax-activation-api): 1.2.0-3
Pipeline: Input Step (pipeline-input-step): 449.v77f0e8b_845c4
Timestamper (timestamper): 1.18
Blue Ocean Pipeline Editor (blueocean-pipeline-editor): 1.25.5
Favorite (favorite): 2.4.1
JavaScript GUI Lib: ACE Editor bundle plugin (ace-editor): 1.1
Build Timeout (build-timeout): 1.23
Display URL for Blue Ocean (blueocean-display-url): 2.4.1
Gradle Plugin (gradle): 1.39.4
Command Agent Launcher Plugin (command-launcher): 1.2
Matrix Authorization Strategy Plugin (matrix-auth): 3.1.5
Resource Disposer Plugin (resource-disposer): 0.19
Workspace Cleanup Plugin (ws-cleanup): 0.42
Credentials Plugin (credentials): 1139.veb_9579fca_33b_
LDAP Plugin (ldap): 2.12
Pipeline: Stage Step (pipeline-stage-step): 293.v200037eefcd5
Variant Plugin (variant): 1.4
OkHttp Plugin (okhttp-api): 4.9.3-108.v0feda04578cf
Matrix Project Plugin (matrix-project): 772.v494f19991984
JSch dependency plugin (jsch): 0.1.55.2
Git plugin (git): 4.11.5
Display URL API (display-url-api): 2.3.6
Checks API plugin (checks-api): 1.7.4
JQuery3 API Plugin (jquery3-api): 3.6.0-4
Plugin Utilities API Plugin (plugin-util-api): 2.17.0
Pipeline: Model API (pipeline-model-api): 2.2097.v33db_b_de764b_e
Font Awesome API Plugin (font-awesome-api): 6.1.1-1
Config API for Blue Ocean (blueocean-config): 1.25.5
Pipeline: Groovy (workflow-cps): 2729.vea_17b_79ed57a_
Personalization for Blue Ocean (blueocean-personalization): 1.25.5
Pipeline: Basic Steps (workflow-basic-steps): 969.vc4ec3e4854b_f
Script Security Plugin (script-security): 1175.v4b_d517d6db_f0
JavaScript GUI Lib: Moment.js bundle plugin (momentjs): 1.1.1
Events API for Blue Ocean (blueocean-events): 1.25.5
Apache HttpComponents Client 4.x API Plugin (apache-httpcomponents-client-4-api): 4.5.13-1.0
Ant Plugin (ant): 475.vf34069fef73c
Autofavorite for Blue Ocean (blueocean-autofavorite): 1.2.5
# I keep the version in the master. It's just a test
GitLab Branch Source Plugin (gitlab-branch-source): 999999-SNAPSHOT (private-55fd8144-didier)
Web for Blue Ocean (blueocean-web): 1.25.5
JDK Tool Plugin (jdk-tool): 1.0
Pipeline: Groovy Libraries (pipeline-groovy-lib): 593.va_a_fc25d520e9
Common API for Blue Ocean (blueocean-commons): 1.25.5
SSH server (sshd): 3.0.3
Java JSON Web Token (JJWT) Plugin (jjwt-api): 0.11.5-77.v646c772fddb_0
GitHub plugin (github): 1.34.3
Blue Ocean (blueocean): 1.25.5
Jersey 2 API (jersey2-api): 2.36-2
Pipeline: Step API (workflow-step-api): 625.vd896b_f445a_f8
REST API for Blue Ocean (blueocean-rest): 1.25.5
Pipeline: GitHub Groovy Libraries (pipeline-github-lib): 38.v445716ea_edda_
Jakarta Mail API (jakarta-mail-api): 2.0.1-1
JAXB plugin (jaxb): 2.3.6-1
Git Pipeline for Blue Ocean (blueocean-git-pipeline): 1.25.5
Pipeline: Stage View Plugin (pipeline-stage-view): 2.24
Pipeline implementation for Blue Ocean (blueocean-pipeline-api-impl): 1.25.5
Pipeline: API (workflow-api): 1188.v0016b_4f29881
Branch API Plugin (branch-api): 2.1046.v0ca_37783ecc5
Mailer Plugin (mailer): 435.v79ef3972b_5c7
GitHub API Plugin (github-api): 1.303-400.v35c2d8258028
Pipeline: Stage Tags Metadata (pipeline-stage-tags-metadata): 2.2097.v33db_b_de764b_e
JavaScript GUI Lib: Handlebars bundle plugin (handlebars): 3.0.8
Design Language (jenkins-design-language): 1.25.5
Jackson 2 API Plugin (jackson2-api): 2.13.3-285.vc03c0256d517
SCM API Plugin (scm-api): 608.vfa_f971c5a_a_e9
Pipeline: REST API Plugin (pipeline-rest-api): 2.24
```

</details>