### PR TITLE
Remove deprecated `javaLevel` parameter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 def configurations = [
     [ platform: "linux", jdk: "8", jenkins: null ],
     [ platform: "windows", jdk: "8", jenkins: null ],
-    [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
-    [ platform: "windows", jdk: "11", jenkins: null, javaLevel: "8" ]
+    [ platform: "linux", jdk: "11", jenkins: null ],
+    [ platform: "windows", jdk: "11", jenkins: null ]
 ]
 buildPlugin(configurations: configurations)


### PR DESCRIPTION
From the latest CI build:

> WARNING: Ignoring deprecated `javaLevel` parameter. This parameter should be removed from your `Jenkinsfile`.