### PR TITLE
Allow to discover MRs from forked projects

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -332,7 +332,13 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                         request.setMergeRequests(mrs);
                     } else {
                         listener.getLogger()
-                            .format("%nIgnoring merge requests as project is a mirror...%n");
+                            .format(
+                                "%nCollecting MRs for fork except those that target its upstream...%n");
+                        List<MergeRequest> mrs = gitLabApi.getMergeRequestApi()
+                            .getMergeRequests(gitlabProject, Constants.MergeRequestState.OPENED);
+                        mrs = mrs.stream().filter(mr -> mr.getSourceProjectId() != null && !mr.getTargetProjectId().equals(gitlabProject.getForkedFromProject().getId()) )
+                            .collect(Collectors.toList());
+                        request.setMergeRequests(mrs);
                     }
                 }
                 if (request.isFetchTags()) {


### PR DESCRIPTION
At the moment, there is no way to detect MR from a forked project. Although working with forked projects is a real and commonly used scenario.
This change allows to discover MRs from forked projects.

Resolves: https://github.com/jenkinsci/gitlab-branch-source-plugin/issues/167

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
