### PR TITLE
Implementation of mark-unstable-as-success logic

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -115,6 +115,8 @@ public class GitLabSCMNavigator extends SCMNavigator {
     private boolean wantSubGroupProjects;
     private transient GitLabOwner gitlabOwner; // TODO check if a better data structure can be used
 
+    private boolean markUnstableAsSuccess;
+
     @DataBoundConstructor
     public GitLabSCMNavigator(String projectOwner) {
         this.projectOwner = projectOwner;
@@ -158,6 +160,15 @@ public class GitLabSCMNavigator extends SCMNavigator {
 
     public String getProjectOwner() {
         return projectOwner;
+    }
+
+    public boolean getMarkUnstableAsSuccess() {
+        return markUnstableAsSuccess;
+    }
+
+    @DataBoundSetter
+    public void setMarkUnstableAsSuccess(boolean markUnstableAsSuccess) {
+        this.markUnstableAsSuccess = markUnstableAsSuccess;
     }
 
     /**
@@ -260,6 +271,7 @@ public class GitLabSCMNavigator extends SCMNavigator {
                 count++;
                 String projectPathWithNamespace = p.getPathWithNamespace();
                 String projectOwner = getProjectOwnerFromNamespace(projectPathWithNamespace);
+                boolean markUnstableAsSuccess = getMarkUnstableAsSuccess();
                 String projectName = getProjectName(gitLabApi, request.withProjectNamingStrategy(), p);
                 getNavigatorProjects().add(projectPathWithNamespace);
                 if (StringUtils.isEmpty(p.getDefaultBranch())) {
@@ -294,7 +306,8 @@ public class GitLabSCMNavigator extends SCMNavigator {
                         credentialsId,
                         projectOwner,
                         projectPathWithNamespace,
-                        name
+                        name,
+                        markUnstableAsSuccess
                     ).withTraits(traits).build(),
                     null,
                     (Witness) (name, isMatch) -> {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -115,6 +115,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     private String httpRemote;
     private transient Project gitlabProject;
     private long projectId;
+    private boolean markUnstableAsSuccess;
 
     /**
      * The cache of {@link ObjectMetadataAction} instances for each open MR.
@@ -128,10 +129,11 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     private transient /* effectively final */ Map<Long, ContributorMetadataAction> mergeRequestContributorCache = new ConcurrentHashMap<>();
 
     @DataBoundConstructor
-    public GitLabSCMSource(String serverName, String projectOwner, String projectPath) {
+    public GitLabSCMSource(String serverName, String projectOwner, String projectPath, boolean markUnstableAsSuccess) {
         this.serverName = serverName;
         this.projectOwner = projectOwner;
         this.projectPath = projectPath;
+        this.markUnstableAsSuccess = markUnstableAsSuccess;
     }
 
     public String getServerName() {
@@ -140,6 +142,10 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
 
     public String getProjectOwner() {
         return projectOwner;
+    }
+
+    public boolean getMarkUnstableAsSuccess() {
+        return markUnstableAsSuccess;
     }
 
     public String getProjectPath() {
@@ -173,6 +179,11 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
      */
     public void setProjectName(String projectName) {
         this.projectName = projectName;
+    }
+
+    @DataBoundSetter
+    public void setMarkUnstableAsSuccess(boolean markUnstableAsSuccess) {
+        this.markUnstableAsSuccess = markUnstableAsSuccess;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceBuilder.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceBuilder.java
@@ -19,10 +19,12 @@ public class GitLabSCMSourceBuilder extends
     private final String projectPath;
     @NonNull
     private final String projectName;
+    @NonNull
+    private final boolean markUnstableAsSuccess;
 
     public GitLabSCMSourceBuilder(@CheckForNull String id, @CheckForNull String serverName,
         @CheckForNull String credentialsId, @NonNull String projectOwner,
-        @NonNull String projectPath, @NonNull String projectName) {
+        @NonNull String projectPath, @NonNull String projectName, @NonNull boolean markUnstableAsSuccess) {
         super(GitLabSCMSource.class, projectName);
         this.id = id;
         this.serverName = serverName;
@@ -30,6 +32,7 @@ public class GitLabSCMSourceBuilder extends
         this.projectOwner = projectOwner;
         this.projectPath = projectPath;
         this.projectName = projectName;
+        this.markUnstableAsSuccess = markUnstableAsSuccess;
     }
 
     @CheckForNull
@@ -46,10 +49,11 @@ public class GitLabSCMSourceBuilder extends
     @Override
     public GitLabSCMSource build() {
         // projectName() should have been getProjectName()
-        GitLabSCMSource result = new GitLabSCMSource(serverName, projectOwner, projectPath);
+        GitLabSCMSource result = new GitLabSCMSource(serverName, projectOwner, projectPath, markUnstableAsSuccess);
         result.setId(id);
         result.setCredentialsId(credentialsId);
         result.setTraits(traits());
+        result.setMarkUnstableAsSuccess(markUnstableAsSuccess);
         result.setProjectName(projectName);
         return result;
     }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
@@ -271,8 +271,13 @@ public class GitLabPipelineStatusNotifier {
             state = Constants.CommitBuildState.SUCCESS;
         } else if (Result.UNSTABLE.equals(result)) {
             status.setDescription(build.toString() + ": This commit is unstable with partial failure.");
-            status.setStatus("FAILED");
-            state = Constants.CommitBuildState.FAILED;
+            if (source.getMarkUnstableAsSuccess()) {
+                status.setStatus("SUCCESS");
+                state = Constants.CommitBuildState.SUCCESS;
+            } else {
+                status.setStatus("FAILED");
+                state = Constants.CommitBuildState.FAILED;
+            }
         } else if (Result.FAILURE.equals(result)) {
             status.setDescription(build.toString() + ": There was a failure building this commit.");
             status.setStatus("FAILED");

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator/config.jelly
@@ -13,4 +13,7 @@
   <f:entry title="${%Behaviours}">
     <scm:traits field="traits"/>
   </f:entry>
+  <f:entry title="${%Mark unstable as success}" field="markUnstableAsSuccess">
+    <f:checkbox default="checked"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
@@ -35,4 +35,7 @@
     //     projectOwner.item(0).value = currentPath;
     // })
   </script>
+  <f:entry title="${%Mark unstable as succeess}" field="markUnstableAsSuccess">
+    <f:checkbox default="checked"/>
+  </f:entry>
 </j:jelly>

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceDeserializationTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceDeserializationTest.java
@@ -21,7 +21,7 @@ public class GitLabSCMSourceDeserializationTest {
     @Test
     public void afterRestartingJenkinsTransientFieldsAreNotNull() throws Exception {
         plan.then(j -> {
-            GitLabSCMSourceBuilder sb = new GitLabSCMSourceBuilder(SOURCE_ID, "server", "creds", "po", "group/project", "project");
+            GitLabSCMSourceBuilder sb = new GitLabSCMSourceBuilder(SOURCE_ID, "server", "creds", "po", "group/project", "project", true);
             WorkflowMultiBranchProject project = j.createProject(WorkflowMultiBranchProject.class, PROJECT_NAME);
             project.getSourcesList().add(new BranchSource(sb.build()));
         });


### PR DESCRIPTION
Added a checkbox in the job settings that allows you to set a green mark at Gitlab if the build has an unstable status. Works for groups and for single repository


