### PR TITLE
Webhook secret is deleted by JCasC on every restart #162

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -11,11 +11,12 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.security.ACL;
 import hudson.security.AccessControlled;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import hudson.util.Secret;
 import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -29,6 +30,7 @@ import org.apache.commons.lang.StringUtils;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
 import org.gitlab4j.api.models.User;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -120,9 +122,17 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     private String hooksRootUrl;
 
     /**
-     * The secret token used while setting up hook url in the GitLab server
+     * The credentials id of the secret token used while setting up hook url in the GitLab server
      */
-    private Secret secretToken;
+    @NonNull
+    private String secretTokenCredentialsId;
+
+
+    /**
+     * The credentials matcher for StringCredentials
+     */
+    public static final CredentialsMatcher SECRET_TOKEN_CREDENTIALS_MATCHER = CredentialsMatchers
+        .instanceOf(StringCredentials.class);
 
     /**
      * {@code true} if and only if Jenkins should trigger a build immediately on a
@@ -271,15 +281,47 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     }
 
     @DataBoundSetter
-    public void setSecretToken(Secret token) {
-        this.secretToken = token;
+    public void setSecretTokenCredentialsId(String token) {
+        this.secretTokenCredentialsId = token;
     }
 
-    // TODO: Use some UI element to trigger (what is the best way?)
-    private void generateSecretToken() {
-        byte[] random = new byte[16];   // 16x8=128bit worth of randomness, since we use md5 digest as the API token
-        RANDOM.nextBytes(random);
-        this.secretToken = Secret.decrypt(Util.toHexString(random));
+    public String getSecretTokenCredentialsId() {
+        return secretTokenCredentialsId;
+    }
+
+    /**
+     * Looks up for StringCredentials
+     *
+     * @return {@link StringCredentials}
+     */
+    public StringCredentials getSecretTokenCredentials(AccessControlled context) {
+        Jenkins jenkins = Jenkins.get();
+        if (context == null) {
+            jenkins.checkPermission(CredentialsProvider.USE_OWN);
+            return StringUtils.isBlank(secretTokenCredentialsId) ? null : CredentialsMatchers.firstOrNull( lookupCredentials(
+                                                                                                    StringCredentials.class,
+                                                                                                    jenkins,
+                                                                                                    ACL.SYSTEM,
+                                                                                                    fromUri(defaultIfBlank(serverUrl, GITLAB_SERVER_URL)).build()
+                                                                                                ), withId(secretTokenCredentialsId));
+        } else {
+            context.checkPermission(CredentialsProvider.USE_OWN);
+            if (context instanceof ItemGroup) {
+                return StringUtils.isBlank(secretTokenCredentialsId) ? null : CredentialsMatchers.firstOrNull( lookupCredentials(
+                    StringCredentials.class,
+                    (ItemGroup) context,
+                    ACL.SYSTEM,
+                    fromUri(defaultIfBlank(serverUrl, GITLAB_SERVER_URL)).build()
+                ), withId(secretTokenCredentialsId));
+            } else {
+                return StringUtils.isBlank(secretTokenCredentialsId) ? null : CredentialsMatchers.firstOrNull( lookupCredentials(
+                    StringCredentials.class,
+                    (Item) context,
+                    ACL.SYSTEM,
+                    fromUri(defaultIfBlank(serverUrl, GITLAB_SERVER_URL)).build()
+                ), withId(secretTokenCredentialsId));
+            }
+        }
     }
 
     /**
@@ -290,15 +332,25 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
         return (DescriptorImpl) super.getDescriptor();
     }
 
-    public Secret getSecretToken() {
-        return secretToken;
+    private StringCredentials getSecretTokenCredentials(String secretTokenCredentialsId) {
+        Jenkins jenkins = Jenkins.get();
+        jenkins.checkPermission(Jenkins.ADMINISTER);
+        return StringUtils.isBlank(secretTokenCredentialsId) ? null : CredentialsMatchers.firstOrNull(
+            lookupCredentials(StringCredentials.class, jenkins),
+            withId(secretTokenCredentialsId)
+        );
     }
 
     public String getSecretTokenAsPlainText() {
-        if (this.secretToken == null) {
+        if (this.secretTokenCredentialsId == null) {
             return null;
         }
-        return this.secretToken.getPlainText();
+        StringCredentials credentials = getSecretTokenCredentials(secretTokenCredentialsId);
+        String secretToken = "";
+        if (credentials != null) {
+            secretToken = credentials.getSecret().getPlainText();
+        }
+        return secretToken;
     }
 
     /**
@@ -464,13 +516,11 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
                 try {
                     User user = gitLabApi.getUserApi().getCurrentUser();
                     LOGGER.log(Level.FINEST, String
-                        .format("Connection established with the GitLab Server for %s",
-                            user.getUsername()));
+                        .format("Connection established with the GitLab Server for %s", user.getUsername()));
                     return FormValidation
                         .ok(String.format("Credentials verified for user %s", user.getUsername()));
                 } catch (GitLabApiException e) {
-                    LOGGER.log(Level.SEVERE,
-                        "Failed to connect with GitLab Server - %s", e.getMessage());
+                    LOGGER.log(Level.SEVERE, "Failed to connect with GitLab Server - %s", e.getMessage());
                     return FormValidation.error(e,
                         Messages.GitLabServer_failedValidation(Util.escape(e.getMessage())));
                 }
@@ -499,6 +549,30 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
                     StandardCredentials.class,
                     fromUri(serverUrl).build(),
                     CREDENTIALS_MATCHER
+                );
+        }
+
+        /**
+         * Stapler form completion.
+         *
+         * @param secretTokenCredentialsId the credentials Id
+         * @return the available credentials.
+         */
+        @Restricted(NoExternalUse.class) // stapler
+        @SuppressWarnings("unused")
+        public ListBoxModel doFillSecretTokenCredentialsIdItems(@QueryParameter String serverUrl,
+            @QueryParameter String secretTokenCredentialsId) {
+            Jenkins jenkins = Jenkins.get();
+            if (!jenkins.hasPermission(Jenkins.ADMINISTER)) {
+                return new StandardListBoxModel().includeCurrentValue(secretTokenCredentialsId);
+            }
+            return new StandardListBoxModel()
+                .includeEmptyValue()
+                .includeMatchingAs(ACL.SYSTEM,
+                    jenkins,
+                    StringCredentials.class,
+                    fromUri(serverUrl).build(),
+                    SECRET_TOKEN_CREDENTIALS_MATCHER
                 );
         }
 

--- a/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/config.groovy
+++ b/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/config.groovy
@@ -28,8 +28,8 @@ f.entry(title: _("System Hook"), field: "manageSystemHooks", "description": "Do 
     f.checkbox(title: _("Manage System Hooks"))
 }
 
-f.entry(title: _("Secret Token"), field: "secretToken", "description": "The secret token used while setting up hook url in the GitLab server") {
-    f.password()
+f.entry(title: _("Secret Token"), field: "secretTokenCredentialsId", "description": "The secret token used while setting up hook url in the GitLab server") {
+    c.select(context: app)
 }
 
 f.entry(title: _("Root URL for hooks"), field: "hooksRootUrl", "description": "Jenkins root URL to use in hooks URL (if different from the public Jenkins root URL)") {

--- a/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/help-secretToken.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/help-secretToken.html
@@ -1,3 +1,0 @@
-<div>
-  The secret token is required to authenticate the webhook payloads received from GitLab Server. Use generate secret token from Advanced options or use your own. If you are a old plugin user and did not set a secret token previously and want secret token to applied to the hooks of your existing jobs, you can add the secret token and rescan your jobs. Existing hooks with new secret token will be applied.
-</div>

--- a/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/help-secretTokenCredentialsId.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/help-secretTokenCredentialsId.html
@@ -1,0 +1,3 @@
+<div>
+  The secret token is required to authenticate the webhook payloads received from a GitLab Server. Use generate secret token from Advanced options or use your own. If you are an old plugin user and did not set a secret token previously and want the secret token to be applied to the hooks of your existing jobs, you can add the secret token and rescan your jobs. Existing hooks with new secret token will be applied.
+</div>


### PR DESCRIPTION
Use Jenkins credentials for webhook secret.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
