### PR TITLE
Gitlab Personal Access Token Length Fix

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/credentials/PersonalAccessTokenImpl.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/credentials/PersonalAccessTokenImpl.java
@@ -65,7 +65,7 @@ public class PersonalAccessTokenImpl extends BaseStandardCredentials implements
     @Symbol("gitlabPersonalAccessToken")
     public static class DescriptorImpl extends CredentialsDescriptor {
 
-        private static final int GITLAB_ACCESS_TOKEN_MINIMAL_LENGTH = 20;
+        private static final int GITLAB_ACCESS_TOKEN_MINIMAL_LENGTH = 26;
 
         /**
          * {@inheritDoc}

--- a/src/main/resources/io/jenkins/plugins/gitlabserverconfig/credentials/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabserverconfig/credentials/Messages.properties
@@ -1,3 +1,3 @@
 PersonalAccessTokenImpl.displayName=GitLab Personal Access Token
 PersonalAccessTokenImpl.tokenRequired=Token required
-PersonalAccessTokenImpl.tokenWrongLength=Token should be at least 20 characters long
+PersonalAccessTokenImpl.tokenWrongLength=Token should be at least 26 characters long


### PR DESCRIPTION
Gitlab personal access tokens start with the prefix `glpat-` and the general format of personal access tokens is: `glpat-abc....`. The actual significant section is 20 characters long. That's why `gitlab-branch-source-plugin` enforces 20 characters without prefix but we have checked the incoming HTTP request to GitLab server contains a `private-token` header with the actual value coming from credentials and without `glpat-` prefix. It causes 401 error.

For the actual fix, we can either add a prefix to the HTTP header value or we can increase the token maximum length criteria to 26 characters. Increasing the length seems a less complex solution.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
