### PR TITLE
Update Acknowledgements (Maintainers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,16 +877,14 @@ You can also use file or url to load the script, see [this](https://github.com/j
 
 ## Acknowledgements
 
-This plugin is built and maintained by the Google Summer of Code (GSoC) Team for [Multibranch Pipeline Support for GitLab](https://jenkins.io/projects/gsoc/2019/gitlab-support-for-multibranch-pipeline/).
-
-Maintainers:
+This plugin was built by the Google Summer of Code (GSoC) Team for [Multibranch Pipeline Support for GitLab](https://jenkins.io/projects/gsoc/2019/gitlab-support-for-multibranch-pipeline/):
 
 * [Parichay](https://github.com/baymac)
 * [Marky](https://github.com/markyjackson-taulia)
 * [Joseph](https://github.com/casz)
 * [Justin](https://github.com/justinharringa)
 
-External Support:
+With external support from:
 
 * [Oleg](https://github.com/oleg-nenashev) (The Jenkins Board Member)
 * [Greg](https://github.com/gmessner) (The maintainer of GitLab4J APIs)


### PR DESCRIPTION
Removed the statement about the GSoC team (still) being the maintainers of this project.

According to the [contributions since 2022-0101](https://github.com/jenkinsci/gitlab-branch-source-plugin/graphs/contributors?from=2022-01-01&to=2023-01-27&type=c) of the GSoC team only @jetersen has contributed to this project.

The current maintainers probably should be listed someplace else, like the [official plugin page](https://plugins.jenkins.io/gitlab-branch-source/), I guess.