### PR TITLE
[GitLab Pipeline Status]: do not set final build status while build is still ongoing

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabPipelineStatusNotifier.java
@@ -281,7 +281,7 @@ public class GitLabPipelineStatusNotifier {
     /**
      * Sends notifications to GitLab on Checkout (for the "In Progress" Status).
      */
-    private static void sendNotifications(Run<?, ?> build, TaskListener listener) {
+    private static void sendNotifications(Run<?, ?> build, TaskListener listener, Boolean useResult) {
         GitLabSCMSource source = getSource(build);
         if (source == null) {
             return;
@@ -298,8 +298,11 @@ public class GitLabPipelineStatusNotifier {
                                     + " configured in Jenkins global configuration.");
             return;
         }
-        Result result = build.getResult();
-        LOGGER.log(Level.FINE, String.format("Result: %s", result));
+        Result result = null;
+        if (useResult) {
+            result = build.getResult();
+            LOGGER.log(Level.FINE, String.format("Result: %s", result));
+        }
 
         CommitStatus status = new CommitStatus();
         Constants.CommitBuildState state;
@@ -521,7 +524,7 @@ public class GitLabPipelineStatusNotifier {
                 File changelogFile,
                 SCMRevisionState pollingBaseline) {
             LOGGER.log(Level.FINE, String.format("SCMListener: Checkout > %s", build.getFullDisplayName()));
-            sendNotifications(build, listener);
+            sendNotifications(build, listener, false);
         }
     }
 
@@ -534,14 +537,14 @@ public class GitLabPipelineStatusNotifier {
         @Override
         public void onCompleted(Run<?, ?> build, @NonNull TaskListener listener) {
             LOGGER.log(Level.FINE, String.format("RunListener: Complete > %s", build.getFullDisplayName()));
-            sendNotifications(build, listener);
+            sendNotifications(build, listener, true);
             logComment(build, listener);
         }
 
         @Override
         public void onStarted(Run<?, ?> run, TaskListener listener) {
             LOGGER.log(Level.FINE, String.format("RunListener: Started > %s", run.getFullDisplayName()));
-            sendNotifications(run, listener);
+            sendNotifications(run, listener, false);
         }
     }
 }


### PR DESCRIPTION
Only notify status RUNNING during onStarted() and onCheckout(). Update status based on build result only in onComplete().

https://issues.jenkins.io/browse/JENKINS-70661

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

Please tell me if the code change does not meet your coding guidelines etc. I'm not a Java developer but I will do my best to meet your requirements.
