### PR TITLE
Avoid null pointer exceptions if gitlab server is setup to manage webhooks but no secret token is set

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -228,7 +228,7 @@ public class GitLabHookCreator {
     }
 
     public static boolean isTokenEqual(String str1, String str2) {
-        if(str1 == null && str2.isEmpty()) {
+        if(str1 == null && (str2 == null || str2.isEmpty())) {
             return true;
         }
         if(str1 == null) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebHookAction.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebHookAction.java
@@ -86,7 +86,13 @@ public final class GitLabWebHookAction extends CrumbExclusion implements Unprote
         try {
             List<GitLabServer> servers = GitLabServers.get().getServers();
             for(GitLabServer server: servers) {
-                if(server.getSecretTokenAsPlainText().equals(secretToken) || (server.getSecretTokenAsPlainText().isEmpty() && secretToken == null)) {
+                String currentServerSecretTokenAsPlainText = server.getSecretTokenAsPlainText();
+
+                if(currentServerSecretTokenAsPlainText == null || currentServerSecretTokenAsPlainText.isEmpty()) {
+                    if (secretToken == null || secretToken.isEmpty()) {
+                        return true;
+                    }
+                } else if (currentServerSecretTokenAsPlainText.equals(secretToken)) {
                     return true;
                 }
             }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Our company programmatically sets up gitlab servers using this plugin (we don't use the ui because that isn't persisted when a docker volume is cleared). We set them up to manage webhooks by default. We noticed a breaking change that without setting a secret token, null pointer exceptions would occur.

Here's some example code:

```
	public SCMSource getSCMSource() {
		GitLabServers gitLabServers = GitLabServers.get();

		GitLabServer gitLabServer = new GitLabServer(
			_serverUrl, _GITLAB_SERVER_NAME, PROVIDER_GITLAB);

		boolean shouldManageHooks = Boolean.parseBoolean(
			EnvUtil.getEnv("LCP_CI_SCM_MANAGE_HOOKS"));

		gitLabServer.setManageWebHooks(shouldManageHooks);

		gitLabServers.addServer(gitLabServer);

		GitLabSCMSource scmSource = new GitLabSCMSource(
			_GITLAB_SERVER_NAME, _repositoryOwner, _repositoryFullName);

		scmSource.afterSave();

		scmSource.setCredentialsId(_GITLAB_SERVER_CREDENTIALS_ID);

		return scmSource;
	}
```

```
java.lang.NullPointerException
	at io.jenkins.plugins.gitlabbranchsource.GitLabHookCreator.isTokenEqual(GitLabHookCreator.java:231)
	at io.jenkins.plugins.gitlabbranchsource.GitLabHookCreator.createWebHookWhenMissing(GitLabHookCreator.java:222)
	at io.jenkins.plugins.gitlabbranchsource.GitLabHookCreator.register(GitLabHookCreator.java:97)
	at io.jenkins.plugins.gitlabbranchsource.GitLabSCMSource.afterSave(GitLabSCMSource.java:731)
	at io.jenkins.scm.GitlabSCMSourceConfiguration.getSCMSource(GitlabSCMSourceConfiguration.java:70)
	at io.jenkins.init.SetupJob._setBranchSource(SetupJob.java:166)
	at io.jenkins.init.SetupJob.setupJob(SetupJob.java:59)
Caused: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:104)
Caused: java.lang.Error
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:110)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:175)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1131)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
```

This was quite annoying, so as a workaround, we added this code:

```
gitLabServer.setSecretToken(Secret.fromString(""));
```

This allowed us to initialize our servers, but then we got another error with incoming posts from the webhook:

```
Feb 23 10:40:02.792 build-19 [ci-0] Feb 23, 2023 6:40:02 PM io.jenkins.plugins.gitlabbranchsource.GitLabWebHookAction isValidToken
Feb 23 10:40:02.792 build-19 [ci-0] WARNING: Error while validating token: null
Feb 23 10:40:02.798 build-19 [ci-0] Feb 23, 2023 6:40:02 PM hudson.init.impl.InstallUncaughtExceptionHandler handleException
Feb 23 10:40:02.798 build-19 [ci-0] WARNING: Caught unhandled exception with ID 7cdbceb7-c1b9-4d04-af13-2534598d9313
Feb 23 10:40:02.798 build-19 [ci-0] java.lang.Exception: Expecting a valid secret token
	at org.kohsuke.stapler.HttpResponses.error(HttpResponses.java:92)
	at io.jenkins.plugins.gitlabbranchsource.GitLabWebHookAction.doPost(GitLabWebHookAction.java:75)
	at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
	at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:397)
	at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:409)
	at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:207)
	at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:140)
	at org.kohsuke.stapler.MetaClass$11.doDispatch(MetaClass.java:558)
	at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:59)
	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:766)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:898)
	at org.kohsuke.stapler.MetaClass$9.dispatch(MetaClass.java:475)
	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:766)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:898)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:694)
	at org.kohsuke.stapler.Stapler.service(Stapler.java:240)
```

Couldn't find out exactly why that was occurring, but it was pretty clear that the code wasn't being careful about the secret token being null. I think it's because the `default` gitlab server has `null` for the secret token, and it's probably the first server in the list that is iterated over. 

This PR is an attempt to be more responsible about String values possibly being null.

`getSecretTokenAsPlainText` can return null, so using `.isEmpty` or `.equals` without a null check is irresponsible.

The plugin should allow this secret token being null. Please feel free to take this code as a starting point to implement a fix, or advise what additional changes we should make. We have customers who want to upgrade this plugin due to other bugs, but we are unable to because of this breaking change.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
