### PR TITLE
[JENKINS-70746] Fix missing permission error when processing changes

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -7,6 +7,8 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -24,6 +26,7 @@ import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -374,9 +377,12 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
 
     private StringCredentials getWebhookSecretCredentials(String webhookSecretCredentialsId) {
         Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(Jenkins.ADMINISTER);
-        return StringUtils.isBlank(webhookSecretCredentialsId) ? null : CredentialsMatchers.firstOrNull(
-            lookupCredentials(StringCredentials.class, jenkins),
+        return StringUtils.isBlank(webhookSecretCredentialsId) ? null 
+                : CredentialsMatchers.firstOrNull(lookupCredentials(
+                        StringCredentials.class,
+                        jenkins,
+                        ACL.SYSTEM,
+                        new ArrayList<DomainRequirement>()),
             withId(webhookSecretCredentialsId)
         );
     }

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -8,7 +8,6 @@ import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
-
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -377,7 +376,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
 
     private StringCredentials getWebhookSecretCredentials(String webhookSecretCredentialsId) {
         Jenkins jenkins = Jenkins.get();
-        return StringUtils.isBlank(webhookSecretCredentialsId) ? null 
+        return StringUtils.isBlank(webhookSecretCredentialsId) ? null
                 : CredentialsMatchers.firstOrNull(lookupCredentials(
                         StringCredentials.class,
                         jenkins,


### PR DESCRIPTION
This commit removes the permission check when accessing the webhook secret. Since this can be called from a webhook or systemhook trigger which have no permission context, there is no way (that I know of) to set the right context.

The regression was introduced by https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/267.

This fixes https://github.com/jenkinsci/gitlab-branch-source-plugin/issues/286 and related https://issues.jenkins.io/browse/JENKINS-70746.

I have tested this successfully in our production environment.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
