### PR TITLE
Fix 'disableProjectAvatar' getter; keep value when reconfiguring job

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabAvatarTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabAvatarTrait.java
@@ -33,11 +33,11 @@ public class GitLabAvatarTrait extends SCMSourceTrait {
     protected void decorateContext(SCMSourceContext<?, ?> context) {
         if (context instanceof GitLabSCMSourceContext) {
             GitLabSCMSourceContext ctx = (GitLabSCMSourceContext) context;
-            ctx.withProjectAvatarDisabled(doDisableProjectAvatar());
+            ctx.withProjectAvatarDisabled(isDisableProjectAvatar());
         }
     }
 
-    public boolean doDisableProjectAvatar() {
+    public boolean isDisableProjectAvatar() {
         return disableProjectAvatar;
     }
 


### PR DESCRIPTION
Probably since the feature was introduced, the "disable project avatar" setting gets lost every next time a Jenkins job using that setting gets reconfigured. In the configuration view, the corresponding checkbox does not get checked even though the 'disableProjectAvatar' attribute is set to 'true' because the getter of the attribute does not follow the correct naming scheme.

Fixing this bug by renaming the getter from 'doDisableProjectAvatar' to 'isDisableProjectAvatar' which now allows Jenkins to pick up the actual value for the checkbox.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
