### PR TITLE
Fix case where "SecretTokenAsPlainText" is null

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -86,9 +86,13 @@ public class GitLabHookCreator {
                 return;
         }
         String hookUrl = getHookUrl(server, true);
-        String secretToken = server.getSecretTokenAsPlainText();
         if (hookUrl.equals("")) {
             return;
+        }
+        String secretToken = server.getSecretTokenAsPlainText();
+        if(secretToken == null) {
+            //sending 'null' to GitLab will ignore the value, when we want to update it to be empty.
+            secretToken = "";
         }
         if (credentials != null) {
             try {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -90,8 +90,8 @@ public class GitLabHookCreator {
             return;
         }
         String secretToken = server.getSecretTokenAsPlainText();
-        if(secretToken == null) {
-            //sending 'null' to GitLab will ignore the value, when we want to update it to be empty.
+        if (secretToken == null) {
+            // sending 'null' to GitLab will ignore the value, when we want to update it to be empty.
             secretToken = "";
         }
         if (credentials != null) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -285,6 +285,11 @@ public class GitLabSCMNavigator extends SCMNavigator {
                 try {
                     GitLabServer server = GitLabServers.get().findServer(serverName);
                     if (webhookGitLabApi != null && webHookUrl != null) {
+                        String secretToken = server.getSecretTokenAsPlainText();
+                        if(secretToken == null) {
+                            //sending 'null' to GitLab will ignore the value, when we want to update it to be empty.
+                            secretToken = "";
+                        }
                         observer.getListener()
                                 .getLogger()
                                 .format(
@@ -293,7 +298,7 @@ public class GitLabSCMNavigator extends SCMNavigator {
                                                 webhookGitLabApi,
                                                 projectPathWithNamespace,
                                                 webHookUrl,
-                                                server.getSecretTokenAsPlainText()));
+                                                secretToken));
                     }
                 } catch (GitLabApiException e) {
                     observer.getListener().getLogger().format("Cannot set web hook: %s%n", e.getReason());

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -286,8 +286,8 @@ public class GitLabSCMNavigator extends SCMNavigator {
                     GitLabServer server = GitLabServers.get().findServer(serverName);
                     if (webhookGitLabApi != null && webHookUrl != null) {
                         String secretToken = server.getSecretTokenAsPlainText();
-                        if(secretToken == null) {
-                            //sending 'null' to GitLab will ignore the value, when we want to update it to be empty.
+                        if (secretToken == null) {
+                            // sending 'null' to GitLab will ignore the value, when we want to update it to be empty.
                             secretToken = "";
                         }
                         observer.getListener()
@@ -295,10 +295,7 @@ public class GitLabSCMNavigator extends SCMNavigator {
                                 .format(
                                         "Web hook %s%n",
                                         GitLabHookCreator.createWebHookWhenMissing(
-                                                webhookGitLabApi,
-                                                projectPathWithNamespace,
-                                                webHookUrl,
-                                                secretToken));
+                                                webhookGitLabApi, projectPathWithNamespace, webHookUrl, secretToken));
                     }
                 } catch (GitLabApiException e) {
                     observer.getListener().getLogger().format("Cannot set web hook: %s%n", e.getReason());

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSystemHookAction.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSystemHookAction.java
@@ -84,7 +84,9 @@ public final class GitLabSystemHookAction extends CrumbExclusion implements Unpr
         try {
             List<GitLabServer> servers = GitLabServers.get().getServers();
             for (GitLabServer server : servers) {
-                if (server.getSecretTokenAsPlainText().equals(secretToken)) {
+                String secretTokenAsPlainText = server.getSecretTokenAsPlainText();
+                if (Objects.equals(secretToken, secretTokenAsPlainText)
+                        || (secretTokenAsPlainText != null && secretTokenAsPlainText.isEmpty() && secretToken == null)) {
                     return true;
                 }
             }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSystemHookAction.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSystemHookAction.java
@@ -8,6 +8,7 @@ import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.FilterChain;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSystemHookAction.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSystemHookAction.java
@@ -87,7 +87,9 @@ public final class GitLabSystemHookAction extends CrumbExclusion implements Unpr
             for (GitLabServer server : servers) {
                 String secretTokenAsPlainText = server.getSecretTokenAsPlainText();
                 if (Objects.equals(secretToken, secretTokenAsPlainText)
-                        || (secretTokenAsPlainText != null && secretTokenAsPlainText.isEmpty() && secretToken == null)) {
+                        || (secretTokenAsPlainText != null
+                                && secretTokenAsPlainText.isEmpty()
+                                && secretToken == null)) {
                     return true;
                 }
             }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebHookAction.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebHookAction.java
@@ -87,7 +87,9 @@ public final class GitLabWebHookAction extends CrumbExclusion implements Unprote
             for (GitLabServer server : servers) {
                 String secretTokenAsPlainText = server.getSecretTokenAsPlainText();
                 if (Objects.equals(secretToken, secretTokenAsPlainText)
-                        || (secretTokenAsPlainText != null && secretTokenAsPlainText.isEmpty() && secretToken == null)) {
+                        || (secretTokenAsPlainText != null
+                                && secretTokenAsPlainText.isEmpty()
+                                && secretToken == null)) {
                     return true;
                 }
             }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebHookAction.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebHookAction.java
@@ -8,6 +8,7 @@ import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.FilterChain;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebHookAction.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebHookAction.java
@@ -84,8 +84,9 @@ public final class GitLabWebHookAction extends CrumbExclusion implements Unprote
         try {
             List<GitLabServer> servers = GitLabServers.get().getServers();
             for (GitLabServer server : servers) {
-                if (server.getSecretTokenAsPlainText().equals(secretToken)
-                        || (server.getSecretTokenAsPlainText().isEmpty() && secretToken == null)) {
+                String secretTokenAsPlainText = server.getSecretTokenAsPlainText();
+                if (Objects.equals(secretToken, secretTokenAsPlainText)
+                        || (secretTokenAsPlainText != null && secretTokenAsPlainText.isEmpty() && secretToken == null)) {
                     return true;
                 }
             }


### PR DESCRIPTION
Fixes #304
Fixes #292

`getSecretTokenAsPlainText()` can return null, see:
https://github.com/jenkinsci/gitlab-branch-source-plugin/blob/d45c0f4c00428cd0d79ba15af87091708b4b58b8/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java#LL397C1-L407C1

So the code needs to be able to handle the `null` case.

* When updating the Hook registration in GitLab we need to send `""` (since `null` will just preserve the current value)
* When checking the `X-Gitlab-Token` sent by GitLab in the POST request, when the header is absent, this means that the `SecretToken` in Jenkins for that server is expected to be null or empty.

### Testing done

TODO

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
