### PR TITLE
Add support for StringCredentials in credentials configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ After installing the plugin on your Jenkins instance, you need configure your Gi
 
     ii. `Server URL` - Contains the URL to your GitLab Server. By default it is set to "https://gitlab.com". User can modify it to enter their GitLab Server URL e.g. https://gitlab.gnome.org/, http://gitlab.example.com:7990. etc.
 
-    iii. `Credentials` - Contains a list of credentials entries that are of type GitLab Personal Access Token. When no credential has been added it shows "-none-". User can add a credential by clicking "Add" button.
+    iii. `Credentials` - Contains a list of credentials entries that are of type GitLab Personal Access Token or any String Credentials. When no credential has been added it shows "-none-". User can add a credential by clicking "Add" button.
 
     iv. `Mange Web Hook` - If you want the plugin to setup web hook on your GitLab project(s) to get push/mr/tag/note events then check this box.
 
@@ -213,8 +213,7 @@ After installing the plugin on your Jenkins instance, you need configure your Gi
 
    This is a manual setup. To automatically generate Personal Access Token see [next section](#creating-personal-access-token-within-jenkins).
 
-    i. User is required to add a `GitLab Personal Access Token` type credentials entry to securely persist the token
-    inside Jenkins.
+    i. User is required to add a `GitLab Personal Access Token` or any `String Credential` type credentials entry to securely persist the token inside Jenkins.
 
     ii. Generate a `Personal Access Token` on your GitLab Server
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabHookCreator.java
@@ -1,10 +1,11 @@
 package io.jenkins.plugins.gitlabbranchsource;
 
+import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getPrivateTokenAsPlainText;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getProxyConfig;
 
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.UriTemplateBuilder;
-import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
 import java.net.MalformedURLException;
@@ -25,7 +26,7 @@ public class GitLabHookCreator {
 
     public static void register(
             SCMNavigatorOwner owner, GitLabSCMNavigator navigator, GitLabHookRegistration systemhookMode) {
-        PersonalAccessToken credentials;
+        StandardCredentials credentials;
         GitLabServer server = GitLabServers.get().findServer(navigator.getServerName());
         if (server == null) {
             return;
@@ -59,7 +60,7 @@ public class GitLabHookCreator {
 
     public static void register(
             GitLabSCMSource source, GitLabHookRegistration webhookMode, GitLabHookRegistration systemhookMode) {
-        PersonalAccessToken credentials = null;
+        StandardCredentials credentials = null;
         GitLabServer server = GitLabServers.get().findServer(source.getServerName());
         if (server == null) {
             return;
@@ -98,7 +99,7 @@ public class GitLabHookCreator {
             try {
                 GitLabApi gitLabApi = new GitLabApi(
                         server.getServerUrl(),
-                        credentials.getToken().getPlainText(),
+                        getPrivateTokenAsPlainText(credentials),
                         null,
                         getProxyConfig(server.getServerUrl()));
                 createWebHookWhenMissing(gitLabApi, source.getProjectPath(), hookUrl, secretToken);
@@ -137,12 +138,12 @@ public class GitLabHookCreator {
         }
     }
 
-    public static void createSystemHookWhenMissing(GitLabServer server, PersonalAccessToken credentials) {
+    public static void createSystemHookWhenMissing(GitLabServer server, StandardCredentials credentials) {
         String systemHookUrl = getHookUrl(server, false);
         try {
             GitLabApi gitLabApi = new GitLabApi(
                     server.getServerUrl(),
-                    credentials.getToken().getPlainText(),
+                    getPrivateTokenAsPlainText(credentials),
                     null,
                     getProxyConfig(server.getServerUrl()));
             SystemHook systemHook = gitLabApi

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -32,7 +32,7 @@ import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabGroup;
 import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabLink;
 import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabOwner;
 import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabUser;
-import io.jenkins.plugins.gitlabserverconfig.credentials.GitLabCredentialMatcher;
+import io.jenkins.plugins.gitlabserverconfig.credentials.helpers.GitLabCredentialMatcher;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
 import java.io.IOException;

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/credentials/GitLabCredentialMatcher.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/credentials/GitLabCredentialMatcher.java
@@ -1,0 +1,20 @@
+package io.jenkins.plugins.gitlabserverconfig.credentials;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+
+public class GitLabCredentialMatcher implements CredentialsMatcher {
+
+    private static final long serialVersionUID = 1;
+
+    @Override
+    public boolean matches(@NonNull Credentials credentials) {
+        try {
+            return credentials instanceof PersonalAccessToken || credentials instanceof StringCredentials;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/credentials/helpers/GitLabCredentialMatcher.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/credentials/helpers/GitLabCredentialMatcher.java
@@ -1,8 +1,9 @@
-package io.jenkins.plugins.gitlabserverconfig.credentials;
+package io.jenkins.plugins.gitlabserverconfig.credentials.helpers;
 
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 public class GitLabCredentialMatcher implements CredentialsMatcher {

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -28,7 +28,7 @@ import hudson.security.AccessControlled;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
-import io.jenkins.plugins.gitlabserverconfig.credentials.GitLabCredentialMatcher;
+import io.jenkins.plugins.gitlabserverconfig.credentials.helpers.GitLabCredentialMatcher;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.SecureRandom;

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.gitlabserverconfig.servers;
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.withId;
 import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
 import static com.cloudbees.plugins.credentials.domains.URIRequirementBuilder.fromUri;
+import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getPrivateTokenAsPlainText;
 import static io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper.getProxyConfig;
 import static org.apache.commons.lang.StringUtils.defaultIfBlank;
 
@@ -27,7 +28,7 @@ import hudson.security.AccessControlled;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
-import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
+import io.jenkins.plugins.gitlabserverconfig.credentials.GitLabCredentialMatcher;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.SecureRandom;
@@ -59,10 +60,9 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
 
     /**
-     * The credentials matcher for GitLab Personal Access Token
+     * The credentials matcher for PersonalAccessToken and StringCredentials
      */
-    public static final CredentialsMatcher CREDENTIALS_MATCHER =
-            CredentialsMatchers.instanceOf(PersonalAccessToken.class);
+    public static final CredentialsMatcher CREDENTIALS_MATCHER = new GitLabCredentialMatcher();
     /**
      * Default name for community SaaS version server
      */
@@ -115,7 +115,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     private boolean manageSystemHooks;
 
     /**
-     * The {@link PersonalAccessToken#getId()} of the credentials to use for
+     * The {@link StandardCredentials#getId()} of the credentials to use for
      * auto-management of
      * hooks.
      */
@@ -165,7 +165,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
      * @param name          A unique name to use to describe the end-point, if empty
      *                      replaced with a random
      *                      name
-     * @param credentialsId The {@link PersonalAccessToken#getId()} of the
+     * @param credentialsId The {@link StandardCredentials#getId()} of the
      *                      credentials to use for
      *                      GitLab Server Authentication to access GitLab APIs
      */
@@ -252,11 +252,11 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     }
 
     /**
-     * Returns The {@link PersonalAccessToken#getId()} of the credentials to use for
+     * Returns The {@link StandardCredentials#getId()} of the credentials to use for
      * GitLab Server
      * Authentication to access GitLab APIs.
      *
-     * @return The {@link PersonalAccessToken#getId()} of the credentials to use for
+     * @return The {@link StandardCredentials#getId()} of the credentials to use for
      *         GitLab Server
      *         Authentication to access GitLab APIs.
      */
@@ -266,11 +266,11 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     }
 
     /**
-     * Looks up for Personal Access Token
+     * Looks up for PersonalAccessToken and StringCredentials
      *
-     * @return {@link PersonalAccessToken}
+     * @return {@link StandardCredentials}
      */
-    public PersonalAccessToken getCredentials(AccessControlled context) {
+    public StandardCredentials getCredentials(AccessControlled context) {
         Jenkins jenkins = Jenkins.get();
         if (context == null) {
             jenkins.checkPermission(CredentialsProvider.USE_OWN);
@@ -281,7 +281,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
                 ? null
                 : CredentialsMatchers.firstOrNull(
                         lookupCredentials(
-                                PersonalAccessToken.class,
+                                StandardCredentials.class,
                                 jenkins,
                                 ACL.SYSTEM,
                                 fromUri(defaultIfBlank(serverUrl, GITLAB_SERVER_URL))
@@ -576,11 +576,8 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
         @Restricted(DoNotUse.class)
         @SuppressWarnings("unused")
         public FormValidation doTestConnection(@QueryParameter String serverUrl, @QueryParameter String credentialsId) {
-            PersonalAccessToken credentials = getCredentials(serverUrl, credentialsId);
-            String privateToken = "";
-            if (credentials != null) {
-                privateToken = credentials.getToken().getPlainText();
-            }
+            StandardCredentials credentials = getCredentials(serverUrl, credentialsId);
+            String privateToken = getPrivateTokenAsPlainText(credentials);
             if (privateToken.equals(EMPTY_TOKEN)) {
                 GitLabApi gitLabApi = new GitLabApi(serverUrl, EMPTY_TOKEN, null, getProxyConfig(serverUrl));
                 try {
@@ -598,7 +595,6 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
                             Messages.GitLabServer_credentialsNotResolved(Util.escape(credentialsId)));
                 }
             } else {
-
                 GitLabApi gitLabApi = new GitLabApi(serverUrl, privateToken, null, getProxyConfig(serverUrl));
                 try {
                     User user = gitLabApi.getUserApi().getCurrentUser();
@@ -662,14 +658,14 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
                             WEBHOOK_SECRET_CREDENTIALS_MATCHER);
         }
 
-        private PersonalAccessToken getCredentials(String serverUrl, String credentialsId) {
+        private StandardCredentials getCredentials(String serverUrl, String credentialsId) {
             Jenkins jenkins = Jenkins.get();
             jenkins.checkPermission(Jenkins.ADMINISTER);
             return StringUtils.isBlank(credentialsId)
                     ? null
                     : CredentialsMatchers.firstOrNull(
                             lookupCredentials(
-                                    PersonalAccessToken.class,
+                                    StandardCredentials.class,
                                     jenkins,
                                     ACL.SYSTEM,
                                     fromUri(defaultIfBlank(serverUrl, GITLAB_SERVER_URL))

--- a/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/help-credentialsId.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer/help-credentialsId.html
@@ -12,13 +12,17 @@
     </li>
   </ul>
 
-  In Jenkins, create a token credential as «<b>GitLab Personal Access Token</b>». Human readable id
-  and description is recommended.
+  In Jenkins, create a token credential as «<b>GitLab Personal Access Token</b>» or any
+  «<b>StringCredentials</b>» type credential (e.g. «<b>"Secret text"</b>» provided by
+  <a href="https://plugins.jenkins.io/plain-credentials">Plain Credentials plugin</a> or
+  «<b>"Vault Secret Text Credential"</b>» provided by
+  <a href="https://plugins.jenkins.io/hashicorp-vault-plugin">HashiCorp Vault plugin</a>).
+  Human-readable id and description is recommended.
   <br/>
 
   <p>
     If you have an existing GitLab login and password you can convert it to a token automatically
-    with the help of <br>
-    «<b>Manage additional GitLab actions</b>» in Advanced section of GitLab Servers.
+    with the help of «<b>Manage additional GitLab actions</b>» in Advanced section of
+    GitLab Servers.
   </p>
 </div>


### PR DESCRIPTION
Currently, the only type of credentials supported by the plugin for configure credentials is **Personal Access Token**. The proposed changes make it possible to use any type of **StringCredentials** type credentials, such as **Secret text** provided by Plain Credentials plugin or **Vault Secret Text Credential** provided by HashiCorp Vault plugin.

I manually tested the plugin's basic functionalities with configured new type credentials, but as I'm just starting to use this plugin, I don't know if there are any edge cases that would be worth checking further.

To be more precise about the tests, I have tested the following:
- **Test connection** in GitLab Server configuration form
- I created an example **Organization Folder** item configured to retrieve projects from a specific GitLab group. **Scan GitLab Group Log** logged the creation of **Multibranch Pipelines** for projects containing Jenkinsfile and configuring a webhook for them (as I marked **Manage Web Hooks** option in the GitLab Server configuration form). After committing sample changes to the project, the pipeline of a specific branch was triggered

I also made a small change to the "Credentials" help window in the GitLab Server configuration form to indicate the possibility to use other credentials type.

This PR can partly resolve #107, because [GitLab plugin](https://plugins.jenkins.io/gitlab-plugin/) also supports **StringCredentials** type credentials, so it will be possible to use one credential configured for both plugins.