### PR TITLE
Fix link to GitLab when server ends with a slash

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
@@ -73,16 +73,27 @@ public class GitLabHelper {
 
     @NonNull
     public static String getServerUrl(GitLabServer server) {
-        return server != null ? server.getServerUrl() : GitLabServer.GITLAB_SERVER_URL;
+        if (server == null) {
+            return GitLabServer.GITLAB_SERVER_URL;
+        }
+        String url = server.getServerUrl();
+        return sanitizeUrlValue(url);
     }
 
     @NonNull
     private static String getServerUrl(String server) {
         if (server.startsWith("http://") || server.startsWith("https://")) {
-            return server;
+            return sanitizeUrlValue(server);
         } else {
             return getServerUrlFromName(server);
         }
+    }
+
+    private static String sanitizeUrlValue(String url) {
+        if (url.endsWith("/")) {
+            return url.substring(0, url.length() - 1);
+        }
+        return url;
     }
 
     public static UriTemplateBuilder getUriTemplateFromServer(String server) {

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelperTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelperTest.java
@@ -1,0 +1,21 @@
+package io.jenkins.plugins.gitlabbranchsource.helpers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
+import org.junit.Test;
+
+public class GitLabHelperTest {
+
+    @Test
+    public void server_url_does_not_have_trailing_slash() {
+        assertThat(GitLabHelper.getServerUrl(null), is("https://gitlab.com"));
+
+        GitLabServer server1 = new GitLabServer("https://company.com/gitlab/", "comp_server", "1245");
+        assertThat(GitLabHelper.getServerUrl(server1), is("https://company.com/gitlab"));
+
+        GitLabServer server2 = new GitLabServer("https://gitlab.example.org", "", "pw-id");
+        assertThat(GitLabHelper.getServerUrl(server2), is("https://gitlab.example.org"));
+    }
+}


### PR DESCRIPTION
Fixes #329

The `GitLabHelper` now handles the case where the server ends with a `/` when computing links.


### Testing done

Tested in a local instance

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

