### PR TITLE
using object_attributes.oldrev for alwaysIgnoreNonCodeRelatedUpdates

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestTrigger.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestTrigger.java
@@ -43,27 +43,7 @@ public class GitLabMergeRequestTrigger extends GitLabMergeRequestSCMEvent {
 
         if (action != null) {
             if (action.equals("update") && context.alwaysIgnoreNonCodeRelatedUpdates()) {
-                if (mrEvent.getChanges().getAssignees() != null) {
-                    shouldBuild = false;
-                }
-
-                if (mrEvent.getChanges().getDescription() != null) {
-                    shouldBuild = false;
-                }
-
-                if (mrEvent.getChanges().getMilestoneId() != null) {
-                    shouldBuild = false;
-                }
-
-                if (mrEvent.getChanges().getTitle() != null) {
-                    shouldBuild = false;
-                }
-
-                if (mrEvent.getChanges().getTotalTimeSpent() != null) {
-                    shouldBuild = false;
-                }
-
-                if (mrEvent.getChanges().getLabels() != null) {
+                if (attributes.getOldrev() == null) {
                     shouldBuild = false;
                 }
             }


### PR DESCRIPTION
Based on https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#merge-request-events, and using https://github.com/gitlab4j/gitlab4j-api/pull/980 , changed the implementation of alwaysIgnoreNonCodeRelatedUpdates to use object_attributes.oldrev

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
