### PR TITLE
Add missing hyphen when computing branch url

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
@@ -106,7 +106,7 @@ public class GitLabHelper {
 
     public static UriTemplate branchUriTemplate(String serverNameOrUrl) {
         return getUriTemplateFromServer(serverNameOrUrl)
-                .template("{/project*}/tree/{branch*}")
+                .template("{/project*}/-/tree/{branch*}")
                 .build();
     }
 


### PR DESCRIPTION
This is a follow up of https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/322 to fix https://github.com/jenkinsci/gitlab-branch-source-plugin/issues/320 for the branch case.

<img width="314" alt="Screenshot 2023-07-07 at 06 33 10" src="https://github.com/jenkinsci/gitlab-branch-source-plugin/assets/1222165/1e196128-120f-4171-a109-d2671d814ca6">


### Testing done

Tested manually

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
