### PR TITLE
[JENKINS-72104] Rename repository browser symbol for compatibility

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabBrowser.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabBrowser.java
@@ -75,7 +75,11 @@ public class GitLabBrowser extends GitRepositoryBrowser {
                 .expand());
     }
 
-    @Symbol("gitLab")
+    // [JENKINS-72104] notes that the symbol 'gitLabBrowser' is used
+    // instead of the preferred 'gitLab' symbol in order to not break
+    // compatibility for existing git plugin users.  The git plugin
+    // already defines a repository browser with the symbol "gitLab".
+    @Symbol("gitLabBrowser")
     @Extension
     public static class DescriptorImpl extends Descriptor<RepositoryBrowser<?>> {
 


### PR DESCRIPTION
[JENKINS-72104] Rename repository browser symbol for compatibility

The [679.v1dfd3604d46e release](https://github.com/jenkinsci/gitlab-branch-source-plugin/releases/tag/679.v1dfd3604d46e) of the GitLab branch source plugin adds the symbol `gitLab` to its implementation of a repository browser in [PR-360](https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/360). The repository browser implementation is used by the git plugin to allow the user to choose the preferred way of displaying links to changes.

Unfortunately, the git plugin already defines the symbol `gitLab` for a repository browser implementation. The addition of the new symbol to the GitLab branch source plugin breaks the configuration as code definitions of git plugin users if they have used the gitLab symbol in their definition of global Pipeline libraries.

https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/360#issuecomment-1741737248 has more details including screenshots.

https://github.com/jenkinsci/bom/runs/17272883656 detected the failure while testing the plugin bill of materials with git plugin 5.2.0 and GitLab branch source plugin 679.v1dfd3604d46e.

### Testing done

Testing confirmed that the bug is repeatable in [JENKINS-72104](https://issues.jenkins.io/browse/JENKINS-72104).  Confirmed with the incremental build that the issue is resolved.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
