### PR TITLE
Describe parameter in javadoc

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/TriggerMRCommentTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/TriggerMRCommentTrait.java
@@ -28,7 +28,7 @@ public class TriggerMRCommentTrait extends SCMSourceTrait {
      * Constructor.
      *
      * @param commentBody the comment body to trigger a new build on
-     * @param onlyTrustedMembersCanTrigger
+     * @param onlyTrustedMembersCanTrigger if true then only trusted members can trigger the job
      */
     @DataBoundConstructor
     public TriggerMRCommentTrait(String commentBody, boolean onlyTrustedMembersCanTrigger) {


### PR DESCRIPTION
## Describe a parameter in javadoc

Remove a javadoc warning that is visible in https://github.com/jenkinsci/gitlab-branch-source-plugin/actions/runs/6363094210/job/17278508906

### Testing done

Confirmed that the javadoc warning is visible without this change and is no longer visible with this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Needs to be labeled `documentation` so that it does not cause a release.  The change is not relevant to users, just developers and those who read the build logs.