### PR TITLE
Fix wrong links to GitLab when server is behind a proxy

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -617,8 +617,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         getGitlabProject();
         List<Action> result = new ArrayList<>();
         if (head instanceof BranchSCMHead) {
-            String branchUrl = branchUriTemplate(serverName)
-                    .set("project", splitPath(projectPath))
+            String branchUrl = branchUriTemplate(gitlabProject.getWebUrl())
                     .set("branch", head.getName())
                     .expand();
             result.add(new ObjectMetadataAction(null, null, branchUrl));
@@ -628,8 +627,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             }
         } else if (head instanceof MergeRequestSCMHead) {
             long iid = Long.parseLong(((MergeRequestSCMHead) head).getId());
-            String mergeUrl = mergeRequestUriTemplate(serverName)
-                    .set("project", splitPath(projectPath))
+            String mergeUrl = mergeRequestUriTemplate(gitlabProject.getWebUrl())
                     .set("iid", iid)
                     .expand();
             ObjectMetadataAction metadataAction = mergeRequestMetadataCache.get(iid);
@@ -644,8 +642,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             }
             result.add(GitLabLink.toMergeRequest(mergeUrl));
         } else if (head instanceof GitLabTagSCMHead) {
-            String tagUrl = tagUriTemplate(serverName)
-                    .set("project", splitPath(projectPath))
+            String tagUrl = tagUriTemplate(gitlabProject.getWebUrl())
                     .set("tag", head.getName())
                     .expand();
             result.add(new ObjectMetadataAction(null, null, tagUrl));
@@ -695,8 +692,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         List<Action> actions = new ArrayList<>();
         if (revision instanceof SCMRevisionImpl) {
             String hash = ((SCMRevisionImpl) revision).getHash();
-            String commitUrl = commitUriTemplate(serverName)
-                    .set("project", splitPath(projectPath))
+            String commitUrl = commitUriTemplate(gitlabProject.getWebUrl())
                     .set("hash", hash)
                     .expand();
             actions.add(GitLabLink.toCommit(commitUrl));

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -605,7 +605,8 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
                             String.format("Connection established with the GitLab Server for %s", user.getUsername()));
                     return FormValidation.ok(String.format("Credentials verified for user %s", user.getUsername()));
                 } catch (GitLabApiException e) {
-                    LOGGER.log(Level.SEVERE, String.format("Failed to connect with GitLab Server - %s", e.getMessage()));
+                    LOGGER.log(
+                            Level.SEVERE, String.format("Failed to connect with GitLab Server - %s", e.getMessage()));
                     return FormValidation.error(e, Messages.GitLabServer_failedValidation(Util.escape(e.getMessage())));
                 }
             }

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -509,7 +509,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
             try {
                 new URL(serverUrl);
             } catch (MalformedURLException e) {
-                LOGGER.log(Level.SEVERE, "Incorrect url: %s", serverUrl);
+                LOGGER.log(Level.SEVERE, String.format("Incorrect url: %s", serverUrl));
                 return FormValidation.error("Malformed url (%s)", e.getMessage());
             }
             if (GITLAB_SERVER_URL.equals(serverUrl)) {
@@ -605,7 +605,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
                             String.format("Connection established with the GitLab Server for %s", user.getUsername()));
                     return FormValidation.ok(String.format("Credentials verified for user %s", user.getUsername()));
                 } catch (GitLabApiException e) {
-                    LOGGER.log(Level.SEVERE, "Failed to connect with GitLab Server - %s", e.getMessage());
+                    LOGGER.log(Level.SEVERE, String.format("Failed to connect with GitLab Server - %s", e.getMessage()));
                     return FormValidation.error(e, Messages.GitLabServer_failedValidation(Util.escape(e.getMessage())));
                 }
             }


### PR DESCRIPTION
Actually, the functionality was already there. Switched from using the GitLab Server URL from the Jenkins config to the public web URL provided by the GitLab server itself.  Also fixed wrong LOGGER calls.

This fixes #380 

### Testing done

Used in test and staging environment. Checked all links inside the scan log, project page, branch page and build page. All links are using the correct URL, now.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
