### PR TITLE
doc: fix creating GitLab Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,9 +411,13 @@ To create a `GitLab Group Job`:
 
 1. Select `New Item` on Jenkins home page.
 
-2. Enter a name for your job, select `GitLab Group` | select `Ok`.
+2. Enter a name for your job.
 
-3. Now you need to configure your jobs.
+3. Select `Organization Folder` as the job type and press the `Ok` button.
+
+4. In `Configuration`, under `Projects`, select `GitLab Group` as the `Repository Sources`.
+
+5. Now you need to configure your jobs.
 
     i. Select `Server` configured in the initial server setup.
 


### PR DESCRIPTION
Updated the old way of creating a new GitLab Group as an Organization Folder.
This issue was detected in https://issues.jenkins.io/browse/JENKINS-69459.
Screen in this Jira issue apply as tests for this pull request.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
