### PR TITLE
Fix JENKINS-69221 - Scan GitLab project fails on MR from private repository: 404 Project Not Found

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -438,14 +438,17 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                             // This is a hack to get the path with namespace of source project for forked
                             // mrs
                             try {
-                                  originProjectPath = gitLabApi
-		                                  .getProjectApi()
-		                                  .getProject(mr.getSourceProjectId())
-		                                  .getPathWithNamespace();
-		                          forkMrSources.put(mr.getSourceProjectId(), originProjectPath);
-                                } catch(GitLabApiException e) {
+                                originProjectPath = gitLabApi
+                                        .getProjectApi()
+                                        .getProject(mr.getSourceProjectId())
+                                        .getPathWithNamespace();
+                                forkMrSources.put(mr.getSourceProjectId(), originProjectPath);
+                            } catch (GitLabApiException e) {
                                 if (e.getHttpStatus() == 404) {
-                                    LOGGER.log(Level.WARNING, "Ignoring this MR, Please check if fork repo have right permission");
+                                    listener.getLogger()
+                                            .format(
+                                                    "%nIgnoring merge requests as source project not found, Please check permission on source repo...%n");
+                                    continue;
                                 } else {
                                     throw e;
                                 }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -437,11 +437,19 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                         if (fork && !forkMrSources.containsKey(mr.getSourceProjectId())) {
                             // This is a hack to get the path with namespace of source project for forked
                             // mrs
-                            originProjectPath = gitLabApi
-                                    .getProjectApi()
-                                    .getProject(mr.getSourceProjectId())
-                                    .getPathWithNamespace();
-                            forkMrSources.put(mr.getSourceProjectId(), originProjectPath);
+                            try {
+                                  originProjectPath = gitLabApi
+		                                  .getProjectApi()
+		                                  .getProject(mr.getSourceProjectId())
+		                                  .getPathWithNamespace();
+		                          forkMrSources.put(mr.getSourceProjectId(), originProjectPath);
+                                } catch(GitLabApiException e) {
+                                if (e.getHttpStatus() == 404) {
+                                    LOGGER.log(Level.WARNING, "Ignoring this MR, Please check if fork repo have right permission");
+                                } else {
+                                    throw e;
+                                }
+                            }
                         } else if (fork) {
                             originProjectPath = forkMrSources.get(mr.getSourceProjectId());
                         }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fix issue with scan GitLab project fails on MR from private repository: 404 Project Not Found

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
