### PR TITLE
Use getObjectAttributes().getAction() to detect merge request creation

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMEvent.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabMergeRequestSCMEvent.java
@@ -28,10 +28,7 @@ public class GitLabMergeRequestSCMEvent extends AbstractGitLabSCMHeadEvent<Merge
     private static Type typeOf(MergeRequestEvent mrEvent) {
         if (mrEvent.getObjectAttributes().getState().equals("closed")) {
             return Type.REMOVED;
-        } else if (mrEvent.getObjectAttributes().getState().equals("opened")
-                && mrEvent.getObjectAttributes()
-                        .getCreatedAt()
-                        .equals(mrEvent.getObjectAttributes().getUpdatedAt())) {
+        } else if (mrEvent.getObjectAttributes().getAction().equals("open")) {
             return Type.CREATED;
         }
         return Type.UPDATED;


### PR DESCRIPTION
After https://gitlab.com/gitlab-org/gitlab/-/merge_requests/143447 a merge request's `created_at` and `updated_at` values may differ when the merge request is first opened. A GitLab merge request can undergo a number of updates as part of its creation. It's best to rely instead on the `object_attributes.action` value in the payload which will match the ones listed here https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#merge-request-events.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
