### PR TITLE
Make `branchesAlwaysIncludedRegex` parameter not required

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/BranchDiscoveryTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/BranchDiscoveryTrait.java
@@ -51,7 +51,6 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
      * Constructor for stapler.
      *
      * @param strategyId the strategy id.
-     * @param branchesAlwaysIncludedRegex the branchesAlwaysIncludedRegex.
      */
     @DataBoundConstructor
     public BranchDiscoveryTrait(int strategyId) {
@@ -86,6 +85,9 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
         return branchesAlwaysIncludedRegex;
     }
 
+    /**
+     * Sets the branchesAlwaysIncludedRegex.
+     */
     @DataBoundSetter
     public void setBranchesAlwaysIncludedRegex(@CheckForNull String branchesAlwaysIncludedRegex) {
         this.branchesAlwaysIncludedRegex = Util.fixEmptyAndTrim(branchesAlwaysIncludedRegex);

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/BranchDiscoveryTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/BranchDiscoveryTrait.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.gitlabbranchsource;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.Util;
 import hudson.util.ListBoxModel;
 import java.util.regex.Pattern;
 import jenkins.scm.api.SCMHead;
@@ -23,6 +24,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * A {@link Discovery} trait for GitLab that will discover branches on the repository.
@@ -52,9 +54,8 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
      * @param branchesAlwaysIncludedRegex the branchesAlwaysIncludedRegex.
      */
     @DataBoundConstructor
-    public BranchDiscoveryTrait(int strategyId, String branchesAlwaysIncludedRegex) {
+    public BranchDiscoveryTrait(int strategyId) {
         this.strategyId = strategyId;
-        this.branchesAlwaysIncludedRegex = branchesAlwaysIncludedRegex;
     }
 
     /**
@@ -83,6 +84,11 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
      */
     public String getBranchesAlwaysIncludedRegex() {
         return branchesAlwaysIncludedRegex;
+    }
+
+    @DataBoundSetter
+    public void setBranchesAlwaysIncludedRegex(@CheckForNull String branchesAlwaysIncludedRegex) {
+        this.branchesAlwaysIncludedRegex = Util.fixEmptyAndTrim(branchesAlwaysIncludedRegex);
     }
 
     /**


### PR DESCRIPTION
fixes the #376 as it introduced a required parameter that is not required.
This also fixes nullability and allows the pattern not to be used when string is empty.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
