### PR TITLE
Add warning while setting a GitLab Multipipeline project or organization folders without Credentials

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -15,6 +15,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -524,6 +525,40 @@ public class GitLabSCMNavigator extends SCMNavigator {
                 }
             }
             return GitLabServers.get().getServerItems();
+        }
+
+        public FormValidation doCheckCredentialsId(
+                @AncestorInPath SCMSourceOwner context, @QueryParameter String serverName, @QueryParameter String value)
+                throws IOException, InterruptedException {
+            if (context == null) {
+                if (Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                    return FormValidation.ok();
+                }
+            } else {
+                if (!context.hasPermission(Item.EXTENDED_READ)
+                        && !context.hasPermission(CredentialsProvider.USE_ITEM)) {
+                    return FormValidation.ok();
+                }
+            }
+            GitLabServer server = GitLabServers.get().findServer(serverName);
+            if (server == null) {
+                return FormValidation.ok();
+            }
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.warning("Credentials are recommended");
+            }
+            if (CredentialsProvider.listCredentialsInItem(
+                            StandardCredentials.class,
+                            context,
+                            context instanceof Queue.Task
+                                    ? ((Queue.Task) context).getDefaultAuthentication2()
+                                    : ACL.SYSTEM2,
+                            URIRequirementBuilder.fromUri(serverName).build(),
+                            GitLabServer.CREDENTIALS_MATCHER)
+                    .isEmpty()) {
+                return FormValidation.error(Messages.GitLabSCMNavigator_selectedCredentialsMissing());
+            }
+            return FormValidation.ok();
         }
 
         public ListBoxModel doFillCredentialsIdItems(

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -17,14 +17,12 @@ import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.Util;
-import hudson.util.FormValidation;
 import hudson.console.HyperlinkNote;
 import hudson.model.Action;
 import hudson.model.Item;
@@ -32,11 +30,11 @@ import hudson.model.Queue;
 import hudson.model.TaskListener;
 import hudson.scm.SCM;
 import hudson.security.ACL;
+import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabAvatar;
 import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabLink;
 import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
-import io.jenkins.plugins.gitlabserverconfig.credentials.helpers.GitLabCredentialMatcher;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
 import java.io.IOException;
@@ -841,32 +839,38 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             return GitLabServers.get().getServerItems();
         }
 
-        public FormValidation doCheckCredentialId(@AncestorInPath SCMSourceOwner context, @QueryParameter String serverName, @QueryParameter String value) throws IOException, InterruptedException {
-           if (context == null) {
-               if (Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
-                   return FormValidation.ok();
+        public FormValidation doCheckCredentialsId(
+                @AncestorInPath SCMSourceOwner context, @QueryParameter String serverName, @QueryParameter String value)
+                throws IOException, InterruptedException {
+            if (context == null) {
+                if (Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                    return FormValidation.ok();
                 }
-           } else {
-               if (!context.hasPermission(Item.EXTENDED_READ) && !context.hasPermission(CredentialsProvider.USE_ITEM)) {
-                   return FormValidation.ok();
-               }
-           }
-           GitLabServer server = GitLabServers.get().findServer(serverName);
-           if (server == null) {
-               return FormValidation.ok();
-           }
-           if (StringUtils.isBlank(value)) {
-               return FormValidation.warning("Credentials are recommended");
-           }
-           if (CredentialsProvider.listCredentialsInItem(
-               StandardCredentials.class,
-               context,
-               context instanceof Queue.Task ? ((Queue.Task) context).getDefaultAuthentication2() : ACL.SYSTEM2,
-               URIRequirementBuilder.fromUri(serverName).build(),
-               GitLabServer.CREDENTIALS_MATCHER).isEmpty()) {
-               return FormValidation.error(Messages.GitLabSCMNavigator_selectedCredentialsMissing());
-           }
-           return FormValidation.ok();
+            } else {
+                if (!context.hasPermission(Item.EXTENDED_READ)
+                        && !context.hasPermission(CredentialsProvider.USE_ITEM)) {
+                    return FormValidation.ok();
+                }
+            }
+            GitLabServer server = GitLabServers.get().findServer(serverName);
+            if (server == null) {
+                return FormValidation.ok();
+            }
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.warning("Credentials are recommended");
+            }
+            if (CredentialsProvider.listCredentialsInItem(
+                            StandardCredentials.class,
+                            context,
+                            context instanceof Queue.Task
+                                    ? ((Queue.Task) context).getDefaultAuthentication2()
+                                    : ACL.SYSTEM2,
+                            URIRequirementBuilder.fromUri(serverName).build(),
+                            GitLabServer.CREDENTIALS_MATCHER)
+                    .isEmpty()) {
+                return FormValidation.error(Messages.GitLabSCMNavigator_selectedCredentialsMissing());
+            }
+            return FormValidation.ok();
         }
 
         public ListBoxModel doFillCredentialsIdItems(


### PR DESCRIPTION
The PR addresses this [issue](https://issues.jenkins.io/browse/JENKINS-71955). While setting up a GitLab multipipeline project or organization folders, a user can choose to not provide any credentials which can lead to an error downstream.
A way to mitigate this is by adding a warning for users to add credentials while still letting them proceed further in the process.

In order to do this, a new validation check `doCheckCredentialsId` has been added to `gitlab-branch-source-plugin/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java` and `gitlab-branch-source-plugin/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java` which checks if credentials are provided or not. The implementation of these is based on the existing [Gitea plugin](https://github.com/jenkinsci/gitea-plugin/blob/master/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSource.java).

Screenshots of the outcome attached below.

![image](https://github.com/jenkinsci/gitlab-branch-source-plugin/assets/32260633/a58bc23f-d1cd-4a05-acff-ab265830894e)
![image](https://github.com/jenkinsci/gitlab-branch-source-plugin/assets/32260633/7d937072-5613-4531-9bae-5ae9d9c243d7)


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
