### PR TITLE
[JENKINS-73061] allow users with Overall/Manage to configure global plugin options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.78</version>
+    <version>4.81</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>
@@ -35,6 +35,8 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
     <hpi.compatibleSinceVersion>685</hpi.compatibleSinceVersion>
+    <!-- Jenkins.MANAGE is still considered beta -->
+    <useBeta>true</useBeta>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -512,7 +512,7 @@ public class GitLabSCMNavigator extends SCMNavigator {
         public ListBoxModel doFillServerNameItems(
                 @AncestorInPath SCMSourceOwner context, @QueryParameter String serverName) {
             if (context == null) {
-                if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                if (!Jenkins.get().hasPermission(Jenkins.MANAGE)) {
                     // must have admin if you want the list without a context
                     ListBoxModel result = new ListBoxModel();
                     result.add(serverName);
@@ -535,7 +535,7 @@ public class GitLabSCMNavigator extends SCMNavigator {
                 @QueryParameter String credentialsId) {
             StandardListBoxModel result = new StandardListBoxModel();
             if (context == null) {
-                if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                if (!Jenkins.get().hasPermission(Jenkins.MANAGE)) {
                     // must have admin if you want the list without a context
                     result.includeCurrentValue(credentialsId);
                     return result;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -819,7 +819,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         public ListBoxModel doFillServerNameItems(
                 @AncestorInPath SCMSourceOwner context, @QueryParameter String serverName) {
             if (context == null) {
-                if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                if (!Jenkins.get().hasPermission(Jenkins.MANAGE)) {
                     // must have admin if you want the list without a context
                     ListBoxModel result = new ListBoxModel();
                     result.add(serverName);
@@ -843,7 +843,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             StandardListBoxModel result = new StandardListBoxModel();
             if (context == null) {
                 // must have admin if you want the list without a context
-                if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                if (!Jenkins.get().hasPermission(Jenkins.MANAGE)) {
                     result.includeCurrentValue(credentialsId);
                     return result;
                 }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/SSHCheckoutTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/SSHCheckoutTrait.java
@@ -88,7 +88,7 @@ public class SSHCheckoutTrait extends SCMSourceTrait {
                 @QueryParameter String credentialsId) {
             StandardListBoxModel result = new StandardListBoxModel();
             if (context == null) {
-                if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                if (!Jenkins.get().hasPermission(Jenkins.MANAGE)) {
                     // must have admin if you want the list without a context
                     result.includeCurrentValue(credentialsId);
                     return result;

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/action/GitlabAction.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/action/GitlabAction.java
@@ -34,7 +34,7 @@ public class GitlabAction implements RootAction {
 
     @RequirePOST
     public HttpResponse doServerList() {
-        if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        if (!Jenkins.get().hasPermission(Jenkins.MANAGE)) {
             return HttpResponses.errorJSON("no permission to get Gitlab server list");
         }
 
@@ -52,7 +52,7 @@ public class GitlabAction implements RootAction {
     @RequirePOST
     public HttpResponse doProjectList(
             @AncestorInPath SCMSourceOwner context, @QueryParameter String server, @QueryParameter String owner) {
-        if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        if (!Jenkins.get().hasPermission(Jenkins.MANAGE)) {
             return HttpResponses.errorJSON("no permission to get Gitlab server list");
         }
 

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -507,7 +507,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
          */
         @POST
         public static FormValidation doCheckServerUrl(@QueryParameter String serverUrl) {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.MANAGE);
             try {
                 new URL(serverUrl);
             } catch (MalformedURLException e) {
@@ -626,7 +626,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
         public ListBoxModel doFillCredentialsIdItems(
                 @QueryParameter String serverUrl, @QueryParameter String credentialsId) {
             Jenkins jenkins = Jenkins.get();
-            if (!jenkins.hasPermission(Jenkins.ADMINISTER)) {
+            if (!jenkins.hasPermission(Jenkins.MANAGE)) {
                 return new StandardListBoxModel().includeCurrentValue(credentialsId);
             }
             return new StandardListBoxModel()
@@ -650,7 +650,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
         public ListBoxModel doFillWebhookSecretCredentialsIdItems(
                 @QueryParameter String serverUrl, @QueryParameter String webhookSecretCredentialsId) {
             Jenkins jenkins = Jenkins.get();
-            if (!jenkins.hasPermission(Jenkins.ADMINISTER)) {
+            if (!jenkins.hasPermission(Jenkins.MANAGE)) {
                 return new StandardListBoxModel().includeCurrentValue(webhookSecretCredentialsId);
             }
             return new StandardListBoxModel()
@@ -665,7 +665,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
 
         private StandardCredentials getCredentials(String serverUrl, String credentialsId) {
             Jenkins jenkins = Jenkins.get();
-            jenkins.checkPermission(Jenkins.ADMINISTER);
+            jenkins.checkPermission(Jenkins.MANAGE);
             return StringUtils.isBlank(credentialsId)
                     ? null
                     : CredentialsMatchers.firstOrNull(

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServers.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServers.java
@@ -8,6 +8,7 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Descriptor;
 import hudson.model.PersistentDescriptor;
+import hudson.security.Permission;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.gitlabserverconfig.servers.helpers.GitLabPersonalAccessTokenCreator;
 import java.util.ArrayList;
@@ -37,6 +38,12 @@ public class GitLabServers extends GlobalConfiguration implements PersistentDesc
      * be one entry for each {@link GitLabServer#getServerUrl()}.
      */
     private List<GitLabServer> servers;
+
+    @NonNull
+    @Override
+    public Permission getRequiredGlobalConfigPagePermission() {
+        return Jenkins.MANAGE;
+    }
 
     /**
      * Gets the {@link GitLabServers} singleton.
@@ -96,7 +103,7 @@ public class GitLabServers extends GlobalConfiguration implements PersistentDesc
      * @param servers the list of endpoints.
      */
     public void setServers(@CheckForNull List<? extends GitLabServer> servers) {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
         this.servers = fixNull(servers).stream()
                 .filter(distinctByKey(GitLabServer::getName))
                 .collect(Collectors.toList());

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/helpers/GitLabPersonalAccessTokenCreator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/helpers/GitLabPersonalAccessTokenCreator.java
@@ -81,7 +81,7 @@ public class GitLabPersonalAccessTokenCreator extends Descriptor<GitLabPersonalA
     public ListBoxModel doFillCredentialsIdItems(
             @QueryParameter String serverUrl, @QueryParameter String credentialsId) {
         Jenkins jenkins = Jenkins.get();
-        if (!jenkins.hasPermission(Jenkins.ADMINISTER)) {
+        if (!jenkins.hasPermission(Jenkins.MANAGE)) {
             return new StandardListBoxModel().includeCurrentValue(credentialsId);
         }
         return new StandardUsernameListBoxModel()
@@ -108,7 +108,7 @@ public class GitLabPersonalAccessTokenCreator extends Descriptor<GitLabPersonalA
             @QueryParameter String serverUrl, @QueryParameter String credentialsId) {
 
         Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(Jenkins.ADMINISTER);
+        jenkins.checkPermission(Jenkins.MANAGE);
         if (isEmpty(credentialsId)) {
             return FormValidation.error("Please specify credentials to create token");
         }
@@ -156,7 +156,7 @@ public class GitLabPersonalAccessTokenCreator extends Descriptor<GitLabPersonalA
     @RequirePOST
     public FormValidation doCreateTokenByPassword(
             @QueryParameter String serverUrl, @QueryParameter String login, @QueryParameter String password) {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
         try {
             String tokenName = UUID.randomUUID().toString();
             String token = AccessTokenUtils.createPersonalAccessToken(


### PR DESCRIPTION
<!-- Please describe your pull request here. -->


https://issues.jenkins.io/browse/JENKINS-73061

Based on [JEP-223](https://github.com/jenkinsci/jep/blob/eedd98dadbf70f69a291c9184facafc64dc82097/jep/223/README.adoc), this operation does not allow users to escalate permissions and it's not related to security, so it qualifies to be accessible with the Overall/Manage permission.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
* Relevant URI related code was reviewed to ensure that `file://` uri's were properly caught
* Installed plugin and manually verified a user with `Overall/Manage` can configure the feature.  Also verified that no information was leaked when attempting to configure dodgy urls like `file://etc/passwd`, and secrets in `JENKINS_HOME`

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
