### PR TITLE
feat: add GITLAB_OA_OLDREV environment variable for merge requests

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/Cause/GitLabMergeRequestCauseData.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/Cause/GitLabMergeRequestCauseData.java
@@ -295,6 +295,9 @@ public class GitLabMergeRequestCauseData {
         this.variables.put(
                 "GITLAB_OA_ACTION",
                 defaultString(mergeRequestEvent.getObjectAttributes().getAction()));
+        this.variables.put(
+                "GITLAB_OA_OLDREV",
+                defaultString(mergeRequestEvent.getObjectAttributes().getOldrev()));
         if (mergeRequestEvent.getObjectAttributes().getAssignee() != null) {
             this.variables.put(
                     "GITLAB_OA_ASSIGNEE_NAME",


### PR DESCRIPTION
Adds the environment variable `GITLAB_OA_OLDREV ` to Merge Request Pipelines.

Allows users to check if there are code changes using their own pipeline and not the plugin settings.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X ] Ensure that the pull request title represents the desired changelog entry
- [ X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
