### PR TITLE
Prevent infinite recursion when migrating secrets to credentials while loading GitLab server configuration

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -407,17 +407,16 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
         return secretToken;
     }
 
-    private Object readResolve() {
-        if (StringUtils.isBlank(webhookSecretCredentialsId) && secretToken != null) {
-            migrateWebhookSecretCredentials();
-        }
-        return this;
-    }
-
     /**
      * Migrate webhook secret token to Jenkins credentials
+     *
+     * @return {@code true} if migration occurred, {@code false} otherwise
+     * @see GitLabServers#migrateWebhookSecretsToCredentials
      */
-    private void migrateWebhookSecretCredentials() {
+    boolean migrateWebhookSecretCredentials() {
+        if (!StringUtils.isBlank(webhookSecretCredentialsId) || secretToken == null) {
+            return false;
+        }
         final List<StringCredentials> credentials = CredentialsProvider.lookupCredentials(
                 StringCredentials.class, Jenkins.get(), ACL.SYSTEM, Collections.emptyList());
         for (final StringCredentials cred : credentials) {
@@ -438,6 +437,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
             webhookSecretCredentialsId = newCredentials.getId();
         }
         secretToken = null;
+        return true;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServers.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServers.java
@@ -6,6 +6,8 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import hudson.model.Descriptor;
 import hudson.model.PersistentDescriptor;
 import hudson.security.Permission;
@@ -195,5 +197,17 @@ public class GitLabServers extends GlobalConfiguration implements PersistentDesc
                 .filter(server -> server.getName().equals(serverName))
                 .findAny()
                 .orElse(null);
+    }
+
+    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED)
+    public static void migrateWebhookSecretsToCredentials() {
+        boolean modified = false;
+        var servers = GitLabServers.get();
+        for (GitLabServer server : servers.getServers()) {
+            modified |= server.migrateWebhookSecretCredentials();
+        }
+        if (modified) {
+            servers.save();
+        }
     }
 }

--- a/src/test/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServersTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServersTest.java
@@ -1,0 +1,70 @@
+package io.jenkins.plugins.gitlabserverconfig.servers;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.diagnosis.OldDataMonitor;
+import hudson.model.ItemGroup;
+import hudson.security.ACL;
+import java.util.List;
+import java.util.logging.Level;
+import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.recipes.LocalData;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
+public class GitLabServersTest {
+    @Rule
+    public LoggerRule logger = new LoggerRule().record(OldDataMonitor.class, Level.FINE).capture(50);;
+    
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    
+    @LocalData
+    @Test
+    public void migrationToCredentials() throws Throwable {
+        // LocalData creating using the following:
+        /*
+        GitLabServer server = new GitLabServer("http://localhost", "my-server", null);
+        server.setSecretToken(Secret.fromString("s3cr3t!"));
+        GitLabServers.get().addServer(server);
+        */
+        var server = GitLabServers.get().getServers().stream().filter(s -> s.getName().equals("my-server")).findFirst().orElseThrow();
+        var credentialsId = server.getWebhookSecretCredentialsId();
+        var credentials = CredentialsMatchers.filter(
+                CredentialsProvider.lookupCredentialsInItemGroup(StringCredentials.class, Jenkins.get(), ACL.SYSTEM2),
+                CredentialsMatchers.withId(credentialsId));
+        assertThat(credentials, hasSize(1));
+        assertThat(credentials.get(0).getSecret().getPlainText(), equalTo("s3cr3t!"));
+        assertThat(logger.getMessages(), not(hasItem(containsString("Trouble loading " + GitLabServers.class.getName()))));
+    }
+
+    @TestExtension("migrationToCredentials")
+    public static class CredentialsProviderThatRequiresDescriptorLookup extends CredentialsProvider {
+        @Override
+        public <C extends Credentials> List<C> getCredentials(
+                @NonNull Class<C> type,
+                @Nullable ItemGroup itemGroup,
+                @Nullable Authentication authentication,
+                @NonNull List<DomainRequirement> domainRequirements) {
+            // Prior to fix, this caused the GitLabServer migration code to recurse infinitely, causing problems when starting Jenkins.
+            // In practice this was caused by a lookup of another descriptor type, but I am using GitLabServers for clarity.
+            Jenkins.get().getDescriptor(GitLabServers.class);
+            return List.of();
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServersTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServersTest.java
@@ -1,5 +1,12 @@
 package io.jenkins.plugins.gitlabserverconfig.servers;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -20,20 +27,15 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.recipes.LocalData;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
 
 public class GitLabServersTest {
     @Rule
-    public LoggerRule logger = new LoggerRule().record(OldDataMonitor.class, Level.FINE).capture(50);;
-    
+    public LoggerRule logger =
+            new LoggerRule().record(OldDataMonitor.class, Level.FINE).capture(50);
+
     @Rule
     public JenkinsRule j = new JenkinsRule();
-    
+
     @LocalData
     @Test
     public void migrationToCredentials() throws Throwable {
@@ -43,14 +45,18 @@ public class GitLabServersTest {
         server.setSecretToken(Secret.fromString("s3cr3t!"));
         GitLabServers.get().addServer(server);
         */
-        var server = GitLabServers.get().getServers().stream().filter(s -> s.getName().equals("my-server")).findFirst().orElseThrow();
+        var server = GitLabServers.get().getServers().stream()
+                .filter(s -> s.getName().equals("my-server"))
+                .findFirst()
+                .orElseThrow();
         var credentialsId = server.getWebhookSecretCredentialsId();
         var credentials = CredentialsMatchers.filter(
                 CredentialsProvider.lookupCredentialsInItemGroup(StringCredentials.class, Jenkins.get(), ACL.SYSTEM2),
                 CredentialsMatchers.withId(credentialsId));
         assertThat(credentials, hasSize(1));
         assertThat(credentials.get(0).getSecret().getPlainText(), equalTo("s3cr3t!"));
-        assertThat(logger.getMessages(), not(hasItem(containsString("Trouble loading " + GitLabServers.class.getName()))));
+        assertThat(
+                logger.getMessages(), not(hasItem(containsString("Trouble loading " + GitLabServers.class.getName()))));
     }
 
     @TestExtension("migrationToCredentials")
@@ -61,8 +67,10 @@ public class GitLabServersTest {
                 @Nullable ItemGroup itemGroup,
                 @Nullable Authentication authentication,
                 @NonNull List<DomainRequirement> domainRequirements) {
-            // Prior to fix, this caused the GitLabServer migration code to recurse infinitely, causing problems when starting Jenkins.
-            // In practice this was caused by a lookup of another descriptor type, but I am using GitLabServers for clarity.
+            // Prior to fix, this caused the GitLabServer migration code to recurse infinitely, causing problems when
+            // starting Jenkins.
+            // In practice this was caused by a lookup of another descriptor type, but I am using GitLabServers for
+            // clarity.
             Jenkins.get().getDescriptor(GitLabServers.class);
             return List.of();
         }

--- a/src/test/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServersTest/migrationToCredentials/io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers.xml
+++ b/src/test/resources/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServersTest/migrationToCredentials/io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers.xml
@@ -1,0 +1,23 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers>
+  <servers>
+    <io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer>
+      <name>default</name>
+      <serverUrl>https://gitlab.com</serverUrl>
+      <manageWebHooks>false</manageWebHooks>
+      <manageSystemHooks>false</manageSystemHooks>
+      <credentialsId></credentialsId>
+      <webhookSecretCredentialsId></webhookSecretCredentialsId>
+      <immediateHookTrigger>false</immediateHookTrigger>
+    </io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer>
+    <io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer>
+      <name>my-server</name>
+      <serverUrl>http://localhost</serverUrl>
+      <manageWebHooks>false</manageWebHooks>
+      <manageSystemHooks>false</manageSystemHooks>
+      <secretToken>s3cr3t!</secretToken> <!-- Manually modified to be plain text rather than the encrypted value so we do not have to store secret.key as a test resource, which makes security scanners unhappy. -->
+      <webhookSecretCredentialsId></webhookSecretCredentialsId>
+      <immediateHookTrigger>false</immediateHookTrigger>
+    </io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer>
+  </servers>
+</io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers>


### PR DESCRIPTION
I recently ran into a case where the migration code in https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/267 was causing an infinite loop while loading extensions during Jenkins startup, leading to various issues.

The problem is that `readResolve` on a class that is part of a `@Extension PersistentDescriptor` will be called while extensions are being loaded because `PersistentDescriptor.load` is annotated with `@PostConstruct` which gets called [here](https://github.com/jenkinsci/jenkins/blob/f6de4582f86a746c143c1c1813e67964da34f9d3/core/src/main/java/hudson/ExtensionFinder.java#L624-L641) when the extension is loaded. This means that it is not safe to do anything that requires other extensions to be loaded from within `load` and any other methods that loading may trigger. In this case the problem was the call to `CredentialsProvider.lookupCredentials` in `GitLabServer.readResolve`. To avoid this issue, I moved the migration to a static `@Initializer` method that runs after `EXTENSIONS_AUGMENTED`, so all extensions have already been loaded at that point.

<details><summary>Here is what the <code>OldDataMonitor</code> warning looked like, filtered to just the repeating stack frames:</summary>

```
INFO    hudson.diagnosis.OldDataMonitor#report: Trouble loading io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers@4a65323
java.lang.StackOverflowError
    ... everything below repeats after this ...
    at jdk.internal.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:568)
    at hudson.ExtensionFinder$GuiceFinder$SezpozModule.onProvision(ExtensionFinder.java:634)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:117)
    at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:66)
    at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:93)
    at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:300)
    at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
    at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169)
    at hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1.get(ExtensionFinder.java:445)
    at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45)
    at com.google.inject.internal.InjectorImpl$1.get(InjectorImpl.java:1148)
    at hudson.ExtensionFinder$GuiceFinder._find(ExtensionFinder.java:403)
    at hudson.ExtensionFinder$GuiceFinder.find(ExtensionFinder.java:394)
    at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:335)
    at hudson.ExtensionList.load(ExtensionList.java:384)
    at hudson.ExtensionList.ensureLoaded(ExtensionList.java:320)
    at hudson.ExtensionList.iterator(ExtensionList.java:172)
    at jenkins.model.Jenkins.getDescriptor(Jenkins.java:1649)
    at io.jenkins.plugins.gitlabserverconfig.servers.GitLabServersTest$CredentialsProviderThatRequiresDescriptorLookup.getCredentials(GitLabServersTest.java:71)
    at com.cloudbees.plugins.credentials.CredentialsProvider.getCredentialsInItemGroup(CredentialsProvider.java:1191)
    at com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentialsInItemGroup(CredentialsProvider.java:389)
    at com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials(CredentialsProvider.java:348)
    at io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer.migrateWebhookSecretCredentials(GitLabServer.java:421)
    at io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer.readResolve(GitLabServer.java:412)
    at jdk.internal.reflect.GeneratedMethodAccessor2.invoke(Unknown Source)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:568)
    at com.thoughtworks.xstream.core.util.SerializationMembers.callReadResolve(SerializationMembers.java:78)
    at hudson.util.RobustReflectionConverter.unmarshal(RobustReflectionConverter.java:290)
    at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:74)
    at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:72)
    at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:68)
    at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:52)
    at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.readBareItem(AbstractCollectionConverter.java:132)
    at hudson.util.RobustCollectionConverter.populateCollection(RobustCollectionConverter.java:87)
    at com.thoughtworks.xstream.converters.collections.CollectionConverter.unmarshal(CollectionConverter.java:81)
    at hudson.util.RobustCollectionConverter.unmarshal(RobustCollectionConverter.java:78)
    at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:74)
    at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:72)
    at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:68)
    at hudson.util.RobustReflectionConverter.unmarshalField(RobustReflectionConverter.java:454)
    at hudson.util.RobustReflectionConverter.doUnmarshal(RobustReflectionConverter.java:350)
    at hudson.util.RobustReflectionConverter.unmarshal(RobustReflectionConverter.java:289)
    at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:74)
    at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:72)
    at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:68)
    at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:52)
    at com.thoughtworks.xstream.core.TreeUnmarshaller.start(TreeUnmarshaller.java:136)
    at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.unmarshal(AbstractTreeMarshallingStrategy.java:32)
    at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1464)
    at hudson.util.XStream2.unmarshal(XStream2.java:230)
    at hudson.util.XStream2.unmarshal(XStream2.java:201)
    at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1441)
    at hudson.XmlFile.unmarshal(XmlFile.java:196)
    at hudson.XmlFile.unmarshal(XmlFile.java:179)
    at hudson.model.Descriptor.load(Descriptor.java:935)
    ...
```
</details> 

There was also this Guice exception in the logs:

```
WARNING h.ExtensionFinder$GuiceFinder$FaultTolerantScope$1#error: Failed to instantiate Key[type=io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers, annotation=[none]]; skipping this component
java.lang.IllegalStateException: Singleton is called recursively returning different results
```

### Testing done

See new automated test.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
