### PR TITLE
Fix JENKINS-71955 NullPointerException because getMergeRequestsEnabled is null

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -116,7 +116,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     private String sshRemote;
     private String httpRemote;
     private transient Project gitlabProject;
-    private long projectId;
+    private Long projectId;
 
     /**
      * The cache of {@link ObjectMetadataAction} instances for each open MR.
@@ -333,7 +333,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 if (request.isFetchBranches()) {
                     request.setBranches(gitLabApi.getRepositoryApi().getBranches(gitlabProject));
                 }
-                if (request.isFetchMRs() && gitlabProject.getMergeRequestsEnabled()) {
+                boolean mergeRequestsEnabled = !Boolean.FALSE.equals(gitlabProject.getMergeRequestsEnabled());
+                if (request.isFetchMRs() && mergeRequestsEnabled) {
                     final boolean forkedFromProject = (gitlabProject.getForkedFromProject() != null);
                     if (!ctx.buildMRForksNotMirror() && forkedFromProject) {
                         listener.getLogger().format("%nIgnoring merge requests as project is a mirror...%n");
@@ -409,7 +410,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     }
                     listener.getLogger().format("%n%d branches were processed%n", count);
                 }
-                if (request.isFetchMRs() && !request.isComplete() && gitlabProject.getMergeRequestsEnabled()) {
+                if (request.isFetchMRs() && !request.isComplete() && mergeRequestsEnabled) {
                     int count = 0;
                     listener.getLogger().format("%nChecking merge requests..%n");
                     HashMap<Long, String> forkMrSources = new HashMap<>();

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
@@ -1,0 +1,72 @@
+package io.jenkins.plugins.gitlabbranchsource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Set;
+
+import org.gitlab4j.api.GitLabApi;
+import org.gitlab4j.api.MergeRequestApi;
+import org.gitlab4j.api.ProjectApi;
+import org.gitlab4j.api.RepositoryApi;
+import org.gitlab4j.api.models.Project;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import hudson.model.TaskListener;
+import hudson.security.AccessControlled;
+import hudson.util.StreamTaskListener;
+import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper;
+import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
+import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
+import jenkins.branch.BranchSource;
+import jenkins.scm.api.SCMHead;
+
+public class GitLabSCMSourceTest {
+
+    private static final String SERVER = "server";
+    private static final String PROJECT_NAME = "project";
+    private static final String SOURCE_ID = "id";
+
+    @Rule
+    public final RestartableJenkinsRule plan = new RestartableJenkinsRule();
+
+    @Test
+    public void retrieveMRWithEmptyProjectSettings() {
+        plan.then(j -> {
+            GitLabApi gitLabApi = Mockito.mock(GitLabApi.class);
+            ProjectApi projectApi = Mockito.mock(ProjectApi.class);
+            RepositoryApi repoApi = Mockito.mock(RepositoryApi.class);
+            MergeRequestApi mrApi = Mockito.mock(MergeRequestApi.class);
+            Mockito.when(gitLabApi.getProjectApi()).thenReturn(projectApi);
+            Mockito.when(gitLabApi.getMergeRequestApi()).thenReturn(mrApi);
+            Mockito.when(gitLabApi.getRepositoryApi()).thenReturn(repoApi);
+            Mockito.when(projectApi.getProject(any())).thenReturn(new Project());
+            try (MockedStatic<GitLabHelper> utilities = Mockito.mockStatic(GitLabHelper.class)) {
+                utilities.when(() -> GitLabHelper.apiBuilder(any(AccessControlled.class), anyString()))
+                        .thenReturn(gitLabApi);
+                GitLabServers.get().addServer(new GitLabServer("", SERVER, ""));
+                GitLabSCMSourceBuilder sb = new GitLabSCMSourceBuilder(SOURCE_ID, SERVER, "creds", "po",
+                        "group/project",
+                        "project");
+                WorkflowMultiBranchProject project = j.createProject(WorkflowMultiBranchProject.class, PROJECT_NAME);
+                BranchSource source = new BranchSource(sb.build());
+                source.getSource()
+                        .setTraits(Arrays.asList(new BranchDiscoveryTrait(0), new OriginMergeRequestDiscoveryTrait(1)));
+                project.getSourcesList().add(source);
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                final TaskListener listener = new StreamTaskListener(out, StandardCharsets.UTF_8);
+                Set<SCMHead> scmHead = source.getSource().fetch(listener);
+                assertEquals(0, scmHead.size());
+            }
+        });
+    }
+}

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
@@ -4,11 +4,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 
+import hudson.model.TaskListener;
+import hudson.security.AccessControlled;
+import hudson.util.StreamTaskListener;
+import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper;
+import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
+import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Set;
-
+import jenkins.branch.BranchSource;
+import jenkins.scm.api.SCMHead;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.MergeRequestApi;
 import org.gitlab4j.api.ProjectApi;
@@ -20,15 +27,6 @@ import org.junit.Test;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-
-import hudson.model.TaskListener;
-import hudson.security.AccessControlled;
-import hudson.util.StreamTaskListener;
-import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper;
-import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
-import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
-import jenkins.branch.BranchSource;
-import jenkins.scm.api.SCMHead;
 
 public class GitLabSCMSourceTest {
 
@@ -51,12 +49,12 @@ public class GitLabSCMSourceTest {
             Mockito.when(gitLabApi.getRepositoryApi()).thenReturn(repoApi);
             Mockito.when(projectApi.getProject(any())).thenReturn(new Project());
             try (MockedStatic<GitLabHelper> utilities = Mockito.mockStatic(GitLabHelper.class)) {
-                utilities.when(() -> GitLabHelper.apiBuilder(any(AccessControlled.class), anyString()))
+                utilities
+                        .when(() -> GitLabHelper.apiBuilder(any(AccessControlled.class), anyString()))
                         .thenReturn(gitLabApi);
                 GitLabServers.get().addServer(new GitLabServer("", SERVER, ""));
-                GitLabSCMSourceBuilder sb = new GitLabSCMSourceBuilder(SOURCE_ID, SERVER, "creds", "po",
-                        "group/project",
-                        "project");
+                GitLabSCMSourceBuilder sb =
+                        new GitLabSCMSourceBuilder(SOURCE_ID, SERVER, "creds", "po", "group/project", "project");
                 WorkflowMultiBranchProject project = j.createProject(WorkflowMultiBranchProject.class, PROJECT_NAME);
                 BranchSource source = new BranchSource(sb.build());
                 source.getSource()

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
@@ -11,20 +11,22 @@ import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Set;
 import jenkins.branch.BranchSource;
 import jenkins.scm.api.SCMHead;
 import org.gitlab4j.api.GitLabApi;
+import org.gitlab4j.api.GitLabApiException;
 import org.gitlab4j.api.MergeRequestApi;
 import org.gitlab4j.api.ProjectApi;
 import org.gitlab4j.api.RepositoryApi;
 import org.gitlab4j.api.models.Project;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -34,37 +36,35 @@ public class GitLabSCMSourceTest {
     private static final String PROJECT_NAME = "project";
     private static final String SOURCE_ID = "id";
 
-    @Rule
-    public final RestartableJenkinsRule plan = new RestartableJenkinsRule();
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void retrieveMRWithEmptyProjectSettings() {
-        plan.then(j -> {
-            GitLabApi gitLabApi = Mockito.mock(GitLabApi.class);
-            ProjectApi projectApi = Mockito.mock(ProjectApi.class);
-            RepositoryApi repoApi = Mockito.mock(RepositoryApi.class);
-            MergeRequestApi mrApi = Mockito.mock(MergeRequestApi.class);
-            Mockito.when(gitLabApi.getProjectApi()).thenReturn(projectApi);
-            Mockito.when(gitLabApi.getMergeRequestApi()).thenReturn(mrApi);
-            Mockito.when(gitLabApi.getRepositoryApi()).thenReturn(repoApi);
-            Mockito.when(projectApi.getProject(any())).thenReturn(new Project());
-            try (MockedStatic<GitLabHelper> utilities = Mockito.mockStatic(GitLabHelper.class)) {
-                utilities
-                        .when(() -> GitLabHelper.apiBuilder(any(AccessControlled.class), anyString()))
-                        .thenReturn(gitLabApi);
-                GitLabServers.get().addServer(new GitLabServer("", SERVER, ""));
-                GitLabSCMSourceBuilder sb =
-                        new GitLabSCMSourceBuilder(SOURCE_ID, SERVER, "creds", "po", "group/project", "project");
-                WorkflowMultiBranchProject project = j.createProject(WorkflowMultiBranchProject.class, PROJECT_NAME);
-                BranchSource source = new BranchSource(sb.build());
-                source.getSource()
-                        .setTraits(Arrays.asList(new BranchDiscoveryTrait(0), new OriginMergeRequestDiscoveryTrait(1)));
-                project.getSourcesList().add(source);
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-                final TaskListener listener = new StreamTaskListener(out, StandardCharsets.UTF_8);
-                Set<SCMHead> scmHead = source.getSource().fetch(listener);
-                assertEquals(0, scmHead.size());
-            }
-        });
+    public void retrieveMRWithEmptyProjectSettings() throws GitLabApiException, IOException, InterruptedException {
+        GitLabApi gitLabApi = Mockito.mock(GitLabApi.class);
+        ProjectApi projectApi = Mockito.mock(ProjectApi.class);
+        RepositoryApi repoApi = Mockito.mock(RepositoryApi.class);
+        MergeRequestApi mrApi = Mockito.mock(MergeRequestApi.class);
+        Mockito.when(gitLabApi.getProjectApi()).thenReturn(projectApi);
+        Mockito.when(gitLabApi.getMergeRequestApi()).thenReturn(mrApi);
+        Mockito.when(gitLabApi.getRepositoryApi()).thenReturn(repoApi);
+        Mockito.when(projectApi.getProject(any())).thenReturn(new Project());
+        try (MockedStatic<GitLabHelper> utilities = Mockito.mockStatic(GitLabHelper.class)) {
+            utilities
+                    .when(() -> GitLabHelper.apiBuilder(any(AccessControlled.class), anyString()))
+                    .thenReturn(gitLabApi);
+            GitLabServers.get().addServer(new GitLabServer("", SERVER, ""));
+            GitLabSCMSourceBuilder sb =
+                    new GitLabSCMSourceBuilder(SOURCE_ID, SERVER, "creds", "po", "group/project", "project");
+            WorkflowMultiBranchProject project = j.createProject(WorkflowMultiBranchProject.class, PROJECT_NAME);
+            BranchSource source = new BranchSource(sb.build());
+            source.getSource()
+                    .setTraits(Arrays.asList(new BranchDiscoveryTrait(0), new OriginMergeRequestDiscoveryTrait(1)));
+            project.getSourcesList().add(source);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            final TaskListener listener = new StreamTaskListener(out, StandardCharsets.UTF_8);
+            Set<SCMHead> scmHead = source.getSource().fetch(listener);
+            assertEquals(0, scmHead.size());
+        }
     }
 }


### PR DESCRIPTION
Fix https://issues.jenkins.io/browse/JENKINS-71955

NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "org.gitlab4j.api.models.Project.getMergeRequestsEnabled()" is null

This is an alternative to https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/406 since this PR really fixes the NPE.

Note that the current title of JENKINS-71955 "GitLab branch source scan fails with null pointer exception if credentials are not provided" is misleading since the NPE also occurs when credentials are provided.

A null getMergeRequestsEnabled seems to be a very common situation, and I cannot find any workaround for this bug in our current Gitlab version (17.5).

According to https://github.com/gitlab4j/gitlab4j-api/blob/fe96001fd18d9411f5b4fbbeeca2377bb3791864/src/main/java/org/gitlab4j/api/ProjectApi.java#L1195

> mergeRequestsEnabled Whether Merge Requests should be enabled, otherwise null indicates to use GitLab default

And according to https://docs.gitlab.com/ee/api/projects.html#create-a-project

> Attribute | Type | Required | Description
> merge_requests_enabled | boolean | No | (Deprecated) Enable merge requests for this project. Use merge_requests_access_level instead.


### Testing done

Added GitLabSCMSourceTest.java

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue