### PR TITLE
[JENKINS-74070] Remove inline script block in `io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly`

### DIFF
--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
@@ -19,20 +19,4 @@
   <f:invisibleEntry>
     <f:number clazz="project-id" field="projectId"/>
   </f:invisibleEntry>
-  <script>
-    // var projectOwner = document.getElementsByClassName('project-owner');
-    //
-    // var projectPath = document.getElementsByClassName('project-path');
-    //
-    // projectPath.addEventListener('change', function() {
-    //     var currentPath = projectPath.value;
-    //     for(var i = currentPath.length-1; i >= 0; i--) {
-    //         currentPath = currentPath.substring(0, currentPath.length-1);
-    //         if(currentPath[i] === '/') {
-    //             break;
-    //         }
-    //     }
-    //     projectOwner.item(0).value = currentPath;
-    // })
-  </script>
 </j:jelly>


### PR DESCRIPTION
Definitely the easiest CSP fix I have seen in this project. All of the code was commented out and thus can trivially be deleted. The code appears to have been commented out since it was originally checked in at commit 0a0471b9c838746c384248a79ad6240fc12de944.

### Testing done

`mvn clean verify`
No manual testing, as this code was commented out all along.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
