### PR TITLE
Multibranch Pipeline Branch Scanning Hang

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -171,6 +171,8 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
      *                      credentials to use for
      *                      GitLab Server Authentication to access GitLab APIs
      */
+    private Integer indexingTimeout = 3600;
+
     @DataBoundConstructor
     public GitLabServer(@NonNull String serverUrl, @NonNull String name, @NonNull String credentialsId) {
         this.serverUrl = defaultIfBlank(StringUtils.trim(serverUrl), GITLAB_SERVER_URL);
@@ -490,6 +492,16 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     @CheckForNull
     public Integer getHookTriggerDelay() {
         return this.hookTriggerDelay;
+    }
+
+    @CheckForNull
+    public Integer getIndexingTimeout() {
+        return indexingTimeout;
+    }
+
+    @DataBoundSetter
+    public void setIndexingTimeout(Integer indexingTimeout) {
+        this.indexingTimeout = indexingTimeout;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -171,8 +171,6 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
      *                      credentials to use for
      *                      GitLab Server Authentication to access GitLab APIs
      */
-    private Integer indexingTimeout = 3600;
-
     @DataBoundConstructor
     public GitLabServer(@NonNull String serverUrl, @NonNull String name, @NonNull String credentialsId) {
         this.serverUrl = defaultIfBlank(StringUtils.trim(serverUrl), GITLAB_SERVER_URL);
@@ -492,16 +490,6 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     @CheckForNull
     public Integer getHookTriggerDelay() {
         return this.hookTriggerDelay;
-    }
-
-    @CheckForNull
-    public Integer getIndexingTimeout() {
-        return indexingTimeout;
-    }
-
-    @DataBoundSetter
-    public void setIndexingTimeout(Integer indexingTimeout) {
-        this.indexingTimeout = indexingTimeout;
     }
 
     /**

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
@@ -16,7 +16,29 @@
   <f:entry title="${%Behaviours}">
     <scm:traits field="traits"/>
   </f:entry>
+  <f:advanced title="${%Advanced}">
+    <f:entry title="${%Indexing Timeout}" description="Maximum time to index a repository (Seconds)">
+      <f:number clazz="indexing-timeout" field="indexingTimeout" default="0"/>
+    </f:entry>
+  </f:advanced>
   <f:invisibleEntry>
     <f:number clazz="project-id" field="projectId"/>
   </f:invisibleEntry>
+
+  <script>
+    // var projectOwner = document.getElementsByClassName('project-owner');
+    //
+    // var projectPath = document.getElementsByClassName('project-path');
+    //
+    // projectPath.addEventListener('change', function() {
+    //     var currentPath = projectPath.value;
+    //     for(var i = currentPath.length-1; i >= 0; i--) {
+    //         currentPath = currentPath.substring(0, currentPath.length-1);
+    //         if(currentPath[i] === '/') {
+    //             break;
+    //         }
+    //     }
+    //     projectOwner.item(0).value = currentPath;
+    // })
+  </script>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
@@ -24,21 +24,4 @@
   <f:invisibleEntry>
     <f:number clazz="project-id" field="projectId"/>
   </f:invisibleEntry>
-
-  <script>
-    // var projectOwner = document.getElementsByClassName('project-owner');
-    //
-    // var projectPath = document.getElementsByClassName('project-path');
-    //
-    // projectPath.addEventListener('change', function() {
-    //     var currentPath = projectPath.value;
-    //     for(var i = currentPath.length-1; i >= 0; i--) {
-    //         currentPath = currentPath.substring(0, currentPath.length-1);
-    //         if(currentPath[i] === '/') {
-    //             break;
-    //         }
-    //     }
-    //     projectOwner.item(0).value = currentPath;
-    // })
-  </script>
 </j:jelly>


### PR DESCRIPTION
## Description of Changes

This pull request introduces a configurable `indexingTimeout` parameter to the `gitlab-branch-source` plugin in Jenkins, enabling users to set a maximum wait time in seconds for indexing GitLab repositories. This timeout is applied in two key methods:

- `retrieve(SCMHead head, TaskListener listener)`: Updated to use an `ExecutorService` and `Future`, allowing the operation to be cancelled if it exceeds the specified timeout.
- `retrieveActions(SCMSourceCriteria criteria, SCMHeadObserver observer, SCMHeadEvent<?> event, TaskListener listener)`: Modified to respect the `indexingTimeout` configuration across the indexing process, including checks on branches, merge requests, and tags.

Additionally, a new `indexingTimeout` property has been added to the UI configuration in the `config-detail.jelly` file, enabling users to set the timeout through Jenkins' interface.

![image](https://github.com/user-attachments/assets/70a7f1b7-c75f-450d-955d-127146c66a01)


## Testing Done

Manual tests were conducted to validate `indexingTimeout` functionality in various scenarios:
1. **Defined Timeout (greater than 0)**: A sample timeout was set, and it was verified that the operation would be interrupted if it exceeded the specified time.

![image](https://github.com/user-attachments/assets/b004808d-0935-420b-b7ec-d03b16b1f0d3)

2. **Undefined Timeout (0)**: Confirmed that the operation continued without interruption when `indexingTimeout` was set to 0.

![image](https://github.com/user-attachments/assets/6bc63be3-430c-4e23-be9c-b88e963de7f3)

4. **Regression**: Tested across different projects and merge requests to ensure the new functionality did not interfere with standard GitLab indexing.

## Submitter Checklist
- [x] Opening from a **topic/feature/bugfix branch** and not from the main branch.
- [x] The pull request title represents the desired changelog entry.
- [x] Clear description of changes made.
- [x] Links to relevant issues in GitHub or Jira.
- [ ] Links to relevant pull requests, especially upstream and downstream changes.
- [x] Provided tests that demonstrate feature works or fixes the issue.
