### PR TITLE
Fix Autoboxing NPE

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -237,12 +237,12 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         return members;
     }
 
-    public long getProjectId() {
+    public Long getProjectId() {
         return projectId;
     }
 
     @DataBoundSetter
-    public void setProjectId(long projectId) {
+    public void setProjectId(Long projectId) {
         this.projectId = projectId;
     }
 

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceDeserializationTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceDeserializationTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.gitlabbranchsource;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.lang.reflect.Field;
@@ -41,6 +42,27 @@ public class GitLabSCMSourceDeserializationTest {
             mergeRequestMetadataCache.setAccessible(true);
             assertNotNull(mergeRequestMetadataCache.get(source));
             assertNotNull(mergeRequestContributorCache.get(source));
+        });
+    }
+
+    @Test
+    public void projectIdSurvivesConfigRoundtrip() {
+        plan.then(j -> {
+            GitLabSCMSourceBuilder sb =
+                new GitLabSCMSourceBuilder(SOURCE_ID, "server", "creds", "po", "group/project", "project");
+            WorkflowMultiBranchProject project = j.createProject(WorkflowMultiBranchProject.class, PROJECT_NAME);
+            GitLabSCMSource source = sb.build();
+            project.getSourcesList().add(new BranchSource(source));
+            long p = 42;
+            source.setProjectId(p);
+            j.configRoundtrip(project);
+
+            WorkflowMultiBranchProject item = j.jenkins.getItemByFullName(PROJECT_NAME,
+                WorkflowMultiBranchProject.class);
+            assertNotNull(item);
+            GitLabSCMSource scmSource = (GitLabSCMSource) item.getSCMSource(SOURCE_ID);
+            assertNotNull(scmSource);
+            assertEquals(Long.valueOf(p), scmSource.getProjectId());
         });
     }
 }


### PR DESCRIPTION
A regression from #456 . When `projectId` is `null` and the untouched `long getProjectId()` is called the JVM will throw a `NullPointerException` because it can't autobox `null` to any value of `long`.

This caused a regression in some script and CasC tools.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
