### PR TITLE
Remove `useBeta` property from `pom.xml`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,12 +33,12 @@
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <!--jenkins.version>${jenkins.baseline}.1</jenkins.version-->
+    <!-- REMOVE -->
+    <jenkins.version>2.495</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
     <hpi.compatibleSinceVersion>685</hpi.compatibleSinceVersion>
-    <!-- Jenkins.MANAGE is still considered beta -->
-    <useBeta>true</useBeta>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Now that the permission `Jenkins.MANAGE` is out of beta (https://github.com/jenkinsci/jenkins/pull/10183) the `useBeta` property is no longer required.

This is still a draft, since it will take some time until that change is shipped in an LTS and this plugin updates to it.
I would like to use this PR as a reminder and update / merge it once the requirements are met.

### Testing done

Validated with `mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
