### PR TITLE
Prepare for Java 25 release Sep 16, 2025

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.7</version>
+    <version>5.18</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -342,8 +342,7 @@ public class GitLabSCMNavigator extends SCMNavigator {
         String fullPath = project.getPathWithNamespace();
         String projectName;
         switch (projectNamingStrategy) {
-            default:
-                // for legacy reasons default naming strategy is set to Full Project path
+            default: // for legacy reasons default naming strategy is set to Full Project path
             case 1:
                 projectName = fullPath;
                 break;


### PR DESCRIPTION
## Prepare for Java 25 release Sep 16, 2025

The Jenkins project strives to support new Java Long Term Support releases soon after they are released.  Java 25 is the next LTS release and is scheduled to release Sep 16, 2025.  The Jenkins project hopes to compile and test Jenkins core and the top 200 Jenkins plugins with Java 25 before Oct 31, 2025.

Without this change, the plugin does not compile with Java 24.  We expect Java 25 will be a superset of Java 24, so let's fix compilation with Java 24 even though Jenkins does not support Java 24.

Also fixes a spotless formatting issue by updating the parent pom.

Supersedes pull requests:

* https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/492
* https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/491

### Testing done

* Confirmed that `mvn spotless:apply` does not change formatting with either Java 17 or Java 21
* Confirmed that `mvn clean verify` passes on Linux with Java 24

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
