### PR TITLE
Multibranch Pipeline Branch Scanning Hang (adopted)

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -252,7 +252,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 if (indexingTimeout != null && indexingTimeout > 0) {
                     future.get(indexingTimeout, TimeUnit.SECONDS);
                 } else {
-                     future.get();
+                    future.get();
                 }
             } catch (InterruptedException | ExecutionException e) {
                 throw new RuntimeException(e);
@@ -262,7 +262,6 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             } catch (Exception e) {
                 throw e;
             }
-
         }
         return gitlabProject;
     }
@@ -755,8 +754,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     protected List<Action> retrieveActions(SCMSourceEvent event, @NonNull TaskListener listener) {
         if (indexingTimeout != null && indexingTimeout > 0) {
             listener.getLogger()
-                .println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: "
-                    + indexingTimeout);
+                    .println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: "
+                            + indexingTimeout);
         } else {
             listener.getLogger().println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: N/A");
         }
@@ -780,8 +779,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     protected List<Action> retrieveActions(@NonNull SCMHead head, SCMHeadEvent event, @NonNull TaskListener listener) {
         if (indexingTimeout != null && indexingTimeout > 0) {
             listener.getLogger()
-                .println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: "
-                    + indexingTimeout);
+                    .println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: "
+                            + indexingTimeout);
         } else {
             listener.getLogger().println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: N/A");
         }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -51,6 +51,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -120,6 +126,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     private String httpRemote;
     private transient Project gitlabProject;
     private Long projectId;
+    private Integer indexingTimeout = 0;
 
     private static final Integer MAX_RETRIES = 5;
 
@@ -194,6 +201,15 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     @DataBoundSetter
     public void setCredentialsId(String credentialsId) {
         this.credentialsId = credentialsId;
+    }
+
+    public Integer getIndexingTimeout() {
+        return indexingTimeout;
+    }
+
+    @DataBoundSetter
+    public void setIndexingTimeout(Integer indexingTimeout) {
+        this.indexingTimeout = indexingTimeout;
     }
 
     @Override
@@ -301,58 +317,88 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     @Override
     protected SCMRevision retrieve(@NonNull SCMHead head, @NonNull TaskListener listener)
             throws IOException, InterruptedException {
+        if (indexingTimeout != null && indexingTimeout > 0) {
+            listener.getLogger()
+                    .println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: "
+                            + indexingTimeout);
+        } else {
+            listener.getLogger().println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: N/A");
+        }
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<SCMRevision> future = null;
         try {
-            GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName, credentialsId);
-            getGitlabProject(gitLabApi);
-            if (head instanceof BranchSCMHead) {
-                listener.getLogger().format("Querying the current revision of branch %s...%n", head.getName());
-                String revision = gitLabApi
-                        .getRepositoryApi()
-                        .getBranch(gitlabProject, head.getName())
-                        .getCommit()
-                        .getId();
-                listener.getLogger().format("Current revision of branch %s is %s%n", head.getName(), revision);
-                return new BranchSCMRevision((BranchSCMHead) head, revision);
-            } else if (head instanceof MergeRequestSCMHead) {
-                MergeRequestSCMHead h = (MergeRequestSCMHead) head;
-                listener.getLogger().format("Querying the current revision of merge request #%s...%n", h.getId());
-                MergeRequest mr =
-                        gitLabApi.getMergeRequestApi().getMergeRequest(gitlabProject, Long.parseLong(h.getId()));
-                String targetSha = gitLabApi
-                        .getRepositoryApi()
-                        .getBranch(mr.getTargetProjectId(), mr.getTargetBranch())
-                        .getCommit()
-                        .getId();
-                if (mr.getState().equals(Constants.MergeRequestState.OPENED.toString())) {
-                    listener.getLogger()
-                            .format("Current revision of merge request #%s is %s%n", h.getId(), mr.getSha());
-                    return new MergeRequestSCMRevision(
-                            h,
-                            new BranchSCMRevision(h.getTarget(), targetSha),
-                            new BranchSCMRevision(new BranchSCMHead(h.getOriginName()), mr.getSha()));
-                } else {
-                    listener.getLogger().format("Merge request #%s is CLOSED%n", h.getId());
-                    return null;
+            future = executor.submit(() -> {
+                try {
+                    GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName, credentialsId);
+                    getGitlabProject(gitLabApi);
+                    if (head instanceof BranchSCMHead) {
+                        listener.getLogger().format("Querying the current revision of branch %s...%n", head.getName());
+                        String revision = gitLabApi
+                                .getRepositoryApi()
+                                .getBranch(gitlabProject, head.getName())
+                                .getCommit()
+                                .getId();
+                        listener.getLogger().format("Current revision of branch %s is %s%n", head.getName(), revision);
+                        return new BranchSCMRevision((BranchSCMHead) head, revision);
+                    } else if (head instanceof MergeRequestSCMHead) {
+                        MergeRequestSCMHead h = (MergeRequestSCMHead) head;
+                        listener.getLogger()
+                                .format("Querying the current revision of merge request #%s...%n", h.getId());
+                        MergeRequest mr = gitLabApi
+                                .getMergeRequestApi()
+                                .getMergeRequest(gitlabProject, Long.parseLong(h.getId()));
+                        String targetSha = gitLabApi
+                                .getRepositoryApi()
+                                .getBranch(mr.getTargetProjectId(), mr.getTargetBranch())
+                                .getCommit()
+                                .getId();
+                        if (mr.getState().equals(Constants.MergeRequestState.OPENED.toString())) {
+                            listener.getLogger()
+                                    .format("Current revision of merge request #%s is %s%n", h.getId(), mr.getSha());
+                            return new MergeRequestSCMRevision(
+                                    h,
+                                    new BranchSCMRevision(h.getTarget(), targetSha),
+                                    new BranchSCMRevision(new BranchSCMHead(h.getOriginName()), mr.getSha()));
+                        } else {
+                            listener.getLogger().format("Merge request #%s is CLOSED%n", h.getId());
+                            return null;
+                        }
+                    } else if (head instanceof GitLabTagSCMHead) {
+                        listener.getLogger().format("Querying the current revision of tag %s...%n", head.getName());
+                        String revision = gitLabApi
+                                .getTagsApi()
+                                .getTag(gitlabProject, head.getName())
+                                .getCommit()
+                                .getId();
+                        listener.getLogger().format("Current revision of tag %s is %s%n", head.getName(), revision);
+                        return new GitTagSCMRevision((GitLabTagSCMHead) head, revision);
+                    } else {
+                        listener.getLogger()
+                                .format(
+                                        "Unknown head: %s of type %s%n",
+                                        head.getName(), head.getClass().getName());
+                        return null;
+                    }
+                } catch (GitLabApiException e) {
+                    LOGGER.log(Level.WARNING, "Exception caught:" + e, e);
+                    throw new IOException("Failed to retrieve the SCM revision for " + head.getName(), e);
                 }
-            } else if (head instanceof GitLabTagSCMHead) {
-                listener.getLogger().format("Querying the current revision of tag %s...%n", head.getName());
-                String revision = gitLabApi
-                        .getTagsApi()
-                        .getTag(gitlabProject, head.getName())
-                        .getCommit()
-                        .getId();
-                listener.getLogger().format("Current revision of tag %s is %s%n", head.getName(), revision);
-                return new GitTagSCMRevision((GitLabTagSCMHead) head, revision);
+            });
+
+            if (indexingTimeout != null && indexingTimeout > 0) {
+                return future.get(indexingTimeout, TimeUnit.SECONDS);
             } else {
-                listener.getLogger()
-                        .format(
-                                "Unknown head: %s of type %s%n",
-                                head.getName(), head.getClass().getName());
-                return null;
+                return future.get();
             }
-        } catch (GitLabApiException e) {
-            LOGGER.log(Level.WARNING, "Exception caught:" + e, e);
-            throw new IOException("Failed to retrieve the SCM revision for " + head.getName(), e);
+        } catch (TimeoutException e) {
+            listener.getLogger().println("SCM revision fetch operation timed out");
+            future.cancel(true);
+            throw new IOException("SCM revision fetch operation timed out", e);
+        } catch (InterruptedException | ExecutionException e) {
+            listener.getLogger().println("Failed to retrieve SCM revision");
+            throw new IOException("Failed to retrieve SCM revision", e);
+        } finally {
+            executor.shutdown();
         }
     }
 
@@ -363,266 +409,312 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             SCMHeadEvent<?> event,
             @NonNull TaskListener listener)
             throws IOException, InterruptedException {
+
+        if (indexingTimeout != null && indexingTimeout > 0) {
+            listener.getLogger()
+                    .println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: "
+                            + indexingTimeout);
+        } else {
+            listener.getLogger().println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: N/A");
+        }
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> future = null;
         try {
-            GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName, credentialsId);
-            getGitlabProject(gitLabApi);
-            GitLabSCMSourceContext ctx = new GitLabSCMSourceContext(criteria, observer).withTraits(getTraits());
-            try (GitLabSCMSourceRequest request = ctx.newRequest(this, listener)) {
-                request.setGitLabApi(gitLabApi);
-                request.setProject(gitlabProject);
-                request.setMembers(getMembers());
-                if (request.isFetchBranches()) {
-                    request.setBranches(gitLabApi.getRepositoryApi().getBranches(gitlabProject));
-                }
-                boolean mergeRequestsEnabled = !Boolean.FALSE.equals(gitlabProject.getMergeRequestsEnabled());
-                if (request.isFetchMRs() && mergeRequestsEnabled) {
-                    final boolean forkedFromProject = (gitlabProject.getForkedFromProject() != null);
-                    if (!ctx.buildMRForksNotMirror() && forkedFromProject) {
-                        listener.getLogger().format("%nIgnoring merge requests as project is a mirror...%n");
-                    } else {
-                        // If not authenticated GitLabApi cannot detect if it is a fork
-                        // If `forkedFromProject` is false it doesn't mean anything
-                        listener.getLogger()
-                                .format(
-                                        !forkedFromProject
-                                                ? "%nUnable to detect if it is a mirror or not still fetching MRs anyway...%n"
-                                                : "%nCollecting MRs for fork except those that target its upstream...%n");
-                        Stream<MergeRequest> mrs =
-                                gitLabApi
+
+            future = executor.submit(() -> {
+                try {
+                    GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName, credentialsId);
+                    getGitlabProject(gitLabApi);
+                    GitLabSCMSourceContext ctx = new GitLabSCMSourceContext(criteria, observer).withTraits(getTraits());
+                    try (GitLabSCMSourceRequest request = ctx.newRequest(this, listener)) {
+                        request.setGitLabApi(gitLabApi);
+                        request.setProject(gitlabProject);
+                        request.setMembers(getMembers());
+                        if (request.isFetchBranches()) {
+                            request.setBranches(gitLabApi.getRepositoryApi().getBranches(gitlabProject));
+                        }
+                        boolean mergeRequestsEnabled = !Boolean.FALSE.equals(gitlabProject.getMergeRequestsEnabled());
+                        if (request.isFetchMRs() && mergeRequestsEnabled) {
+                            final boolean forkedFromProject = (gitlabProject.getForkedFromProject() != null);
+                            if (!ctx.buildMRForksNotMirror() && forkedFromProject) {
+                                listener.getLogger().format("%nIgnoring merge requests as project is a mirror...%n");
+                            } else {
+                                // If not authenticated GitLabApi cannot detect if it is a fork
+                                // If `forkedFromProject` is false it doesn't mean anything
+                                listener.getLogger()
+                                        .format(
+                                                !forkedFromProject
+                                                        ? "%nUnable to detect if it is a mirror or not still fetching MRs anyway...%n"
+                                                        : "%nCollecting MRs for fork except those that target its upstream...%n");
+                                Stream<MergeRequest> mrs = gitLabApi
                                         .getMergeRequestApi()
                                         .getMergeRequests(gitlabProject, MergeRequestState.OPENED)
                                         .stream()
                                         .filter(mr -> mr.getSourceProjectId() != null);
-                        // Patch for issue 453 - avoid an NPE if this isn't a forked project
-                        if (ctx.buildMRForksNotMirror() && forkedFromProject) {
-                            mrs = mrs.filter(mr -> !mr.getTargetProjectId()
-                                    .equals(gitlabProject.getForkedFromProject().getId()));
-                        }
+                                // Patch for issue 453 - avoid an NPE if this isn't a forked project
+                                if (ctx.buildMRForksNotMirror() && forkedFromProject) {
+                                    mrs = mrs.filter(mr -> !mr.getTargetProjectId()
+                                            .equals(gitlabProject
+                                                    .getForkedFromProject()
+                                                    .getId()));
+                                }
 
-                        if (ctx.alwaysIgnoreMRWorkInProgress()) {
-                            mrs = mrs.filter(mr -> !mr.getWorkInProgress());
-                        }
+                                if (ctx.alwaysIgnoreMRWorkInProgress()) {
+                                    mrs = mrs.filter(mr -> !mr.getWorkInProgress());
+                                }
 
-                        request.setMergeRequests(mrs.collect(Collectors.toList()));
-                    }
-                }
-                if (request.isFetchTags()) {
-                    request.setTags(gitLabApi.getTagsApi().getTags(gitlabProject));
-                }
-                if (request.isFetchBranches()) {
-                    int count = 0;
-                    listener.getLogger().format("%nChecking branches.. %n");
-                    Iterable<Branch> branches = request.getBranches();
-                    for (final Branch branch : branches) {
-                        count++;
-                        String branchName = branch.getName();
-                        String sha = branch.getCommit().getId();
-                        listener.getLogger()
-                                .format(
-                                        "%nChecking branch %s%n",
-                                        HyperlinkNote.encodeTo(
-                                                branchUriTemplate(gitlabProject.getWebUrl())
-                                                        .set("branch", splitPath(branchName))
-                                                        .expand(),
-                                                branchName));
-                        if (request.process(
-                                new BranchSCMHead(branchName),
-                                (SCMSourceRequest.RevisionLambda<BranchSCMHead, BranchSCMRevision>)
-                                        head -> new BranchSCMRevision(head, sha),
-                                new SCMSourceRequest.ProbeLambda<BranchSCMHead, BranchSCMRevision>() {
-                                    @NonNull
-                                    @Override
-                                    public SCMSourceCriteria.Probe create(
-                                            @NonNull BranchSCMHead head, @Nullable BranchSCMRevision revision)
-                                            throws IOException {
-                                        return createProbe(head, revision);
-                                    }
-                                },
-                                (SCMSourceRequest.Witness) (head, revision, isMatch) -> {
-                                    if (isMatch) {
-                                        listener.getLogger().format("Met criteria%n");
-                                    } else {
-                                        listener.getLogger().format("Does not meet criteria%n");
-                                    }
-                                })) {
-                            listener.getLogger().format("%n%d branches were processed (query completed)%n", count);
-                            return;
+                                request.setMergeRequests(mrs.collect(Collectors.toList()));
+                            }
                         }
-                    }
-                    listener.getLogger().format("%n%d branches were processed%n", count);
-                }
-                if (request.isFetchMRs() && !request.isComplete() && mergeRequestsEnabled) {
-                    int count = 0;
-                    listener.getLogger().format("%nChecking merge requests..%n");
-                    HashMap<Long, String> forkMrSources = new HashMap<>();
-                    for (MergeRequest mr : request.getMergeRequests()) {
-                        mergeRequestContributorCache.put(
-                                mr.getIid(),
-                                new ContributorMetadataAction(
-                                        mr.getAuthor().getUsername(),
-                                        mr.getAuthor().getName(),
-                                        mr.getAuthor().getEmail()));
-                        mergeRequestMetadataCache.put(
-                                mr.getIid(),
-                                new ObjectMetadataAction(mr.getTitle(), mr.getDescription(), mr.getWebUrl()));
-                        count++;
-                        listener.getLogger()
-                                .format(
-                                        "%nChecking merge request %s%n",
-                                        HyperlinkNote.encodeTo(
-                                                mergeRequestUriTemplate(gitlabProject.getWebUrl())
-                                                        .set("iid", mr.getIid())
-                                                        .expand(),
-                                                "!" + mr.getIid()));
-                        Map<Boolean, Set<ChangeRequestCheckoutStrategy>> strategies = request.getMRStrategies();
-                        boolean fork = !mr.getSourceProjectId().equals(mr.getTargetProjectId());
-                        String originOwner = mr.getAuthor().getUsername();
-                        String originProjectPath = projectPath;
-                        if (fork && !forkMrSources.containsKey(mr.getSourceProjectId())) {
-                            // This is a hack to get the path with namespace of source project for forked
-                            // mrs
-                            try {
-                                originProjectPath = gitLabApi
-                                        .getProjectApi()
-                                        .getProject(mr.getSourceProjectId())
-                                        .getPathWithNamespace();
-                                forkMrSources.put(mr.getSourceProjectId(), originProjectPath);
-                            } catch (GitLabApiException e) {
-                                if (e.getHttpStatus() == 404) {
+                        if (request.isFetchTags()) {
+                            request.setTags(gitLabApi.getTagsApi().getTags(gitlabProject));
+                        }
+                        if (request.isFetchBranches()) {
+                            int count = 0;
+                            listener.getLogger().format("%nChecking branches.. %n");
+                            Iterable<Branch> branches = request.getBranches();
+                            for (final Branch branch : branches) {
+                                count++;
+                                String branchName = branch.getName();
+                                String sha = branch.getCommit().getId();
+                                listener.getLogger()
+                                        .format(
+                                                "%nChecking branch %s%n",
+                                                HyperlinkNote.encodeTo(
+                                                        branchUriTemplate(gitlabProject.getWebUrl())
+                                                                .set("branch", splitPath(branchName))
+                                                                .expand(),
+                                                        branchName));
+                                if (request.process(
+                                        new BranchSCMHead(branchName),
+                                        (SCMSourceRequest.RevisionLambda<BranchSCMHead, BranchSCMRevision>)
+                                                head -> new BranchSCMRevision(head, sha),
+                                        new SCMSourceRequest.ProbeLambda<BranchSCMHead, BranchSCMRevision>() {
+                                            @NonNull
+                                            @Override
+                                            public SCMSourceCriteria.Probe create(
+                                                    @NonNull BranchSCMHead head, @Nullable BranchSCMRevision revision)
+                                                    throws IOException {
+                                                return createProbe(head, revision);
+                                            }
+                                        },
+                                        (SCMSourceRequest.Witness) (head, revision, isMatch) -> {
+                                            if (isMatch) {
+                                                listener.getLogger().format("Met criteria%n");
+                                            } else {
+                                                listener.getLogger().format("Does not meet criteria%n");
+                                            }
+                                        })) {
                                     listener.getLogger()
-                                            .format(
-                                                    "%nIgnoring merge requests as source project not found, Please check permission on source repo...%n");
-                                    continue;
-                                } else {
-                                    throw e;
+                                            .format("%n%d branches were processed (query completed)%n", count);
+                                    return;
                                 }
                             }
-                        } else if (fork) {
-                            originProjectPath = forkMrSources.get(mr.getSourceProjectId());
+                            listener.getLogger().format("%n%d branches were processed%n", count);
                         }
-                        String targetSha;
-                        try {
-                            targetSha = gitLabApi
-                                    .getRepositoryApi()
-                                    .getBranch(mr.getTargetProjectId(), mr.getTargetBranch())
-                                    .getCommit()
-                                    .getId();
-                        } catch (Exception e) {
-                            listener.getLogger()
-                                    .format(
-                                            "Failed getting TargetBranch from Merge Request: " + mr.getIid() + " ("
-                                                    + mr.getTitle() + ")%n%s",
-                                            e);
-                            continue;
-                        }
-                        LOGGER.log(
-                                Level.FINE,
-                                String.format(
-                                        "%s -> %s",
-                                        originOwner, (request.isMember(originOwner) ? "Trusted" : "Untrusted")));
-                        for (ChangeRequestCheckoutStrategy strategy : strategies.get(fork)) {
-                            if (request.process(
-                                    new MergeRequestSCMHead(
-                                            "MR-" + mr.getIid()
-                                                    + (strategies.get(fork).size() > 1
-                                                            ? "-"
-                                                                    + strategy.name()
-                                                                            .toLowerCase(Locale.ENGLISH)
-                                                            : ""),
-                                            mr.getIid(),
-                                            new BranchSCMHead(mr.getTargetBranch()),
-                                            strategy,
-                                            fork ? new SCMHeadOrigin.Fork(originProjectPath) : SCMHeadOrigin.DEFAULT,
-                                            originOwner,
-                                            originProjectPath,
-                                            mr.getSourceBranch(),
-                                            mr.getTitle()),
-                                    (SCMSourceRequest.RevisionLambda<MergeRequestSCMHead, MergeRequestSCMRevision>)
-                                            head -> new MergeRequestSCMRevision(
-                                                    head,
-                                                    new BranchSCMRevision(
-                                                            head.getTarget(),
-                                                            targetSha // Latest revision of target branch
-                                                            ),
-                                                    new BranchSCMRevision(
-                                                            new BranchSCMHead(head.getOriginName()), mr.getSha())),
-                                    new SCMSourceRequest.ProbeLambda<MergeRequestSCMHead, MergeRequestSCMRevision>() {
-                                        @NonNull
-                                        @Override
-                                        public SCMSourceCriteria.Probe create(
-                                                @NonNull MergeRequestSCMHead head,
-                                                @Nullable MergeRequestSCMRevision revision)
-                                                throws IOException, InterruptedException {
-                                            boolean isTrusted = request.isTrusted(head);
-                                            if (!isTrusted) {
-                                                listener.getLogger().format("(not from a trusted source)%n");
-                                            }
-                                            return createProbe(isTrusted ? head : head.getTarget(), revision);
-                                        }
-                                    },
-                                    (SCMSourceRequest.Witness) (head, revision, isMatch) -> {
-                                        if (isMatch) {
-                                            listener.getLogger().format("Met criteria%n");
-                                        } else {
-                                            listener.getLogger().format("Does not meet criteria%n");
-                                        }
-                                    })) {
+                        if (request.isFetchMRs() && !request.isComplete() && mergeRequestsEnabled) {
+                            int count = 0;
+                            listener.getLogger().format("%nChecking merge requests..%n");
+                            HashMap<Long, String> forkMrSources = new HashMap<>();
+                            for (MergeRequest mr : request.getMergeRequests()) {
+                                mergeRequestContributorCache.put(
+                                        mr.getIid(),
+                                        new ContributorMetadataAction(
+                                                mr.getAuthor().getUsername(),
+                                                mr.getAuthor().getName(),
+                                                mr.getAuthor().getEmail()));
+                                mergeRequestMetadataCache.put(
+                                        mr.getIid(),
+                                        new ObjectMetadataAction(mr.getTitle(), mr.getDescription(), mr.getWebUrl()));
+                                count++;
                                 listener.getLogger()
-                                        .format("%n%d merge requests were processed (query completed)%n", count);
-                                return;
+                                        .format(
+                                                "%nChecking merge request %s%n",
+                                                HyperlinkNote.encodeTo(
+                                                        mergeRequestUriTemplate(gitlabProject.getWebUrl())
+                                                                .set("iid", mr.getIid())
+                                                                .expand(),
+                                                        "!" + mr.getIid()));
+                                Map<Boolean, Set<ChangeRequestCheckoutStrategy>> strategies = request.getMRStrategies();
+                                boolean fork = !mr.getSourceProjectId().equals(mr.getTargetProjectId());
+                                String originOwner = mr.getAuthor().getUsername();
+                                String originProjectPath = projectPath;
+                                if (fork && !forkMrSources.containsKey(mr.getSourceProjectId())) {
+                                    // This is a hack to get the path with namespace of source project for forked
+                                    // mrs
+                                    try {
+                                        originProjectPath = gitLabApi
+                                                .getProjectApi()
+                                                .getProject(mr.getSourceProjectId())
+                                                .getPathWithNamespace();
+                                        forkMrSources.put(mr.getSourceProjectId(), originProjectPath);
+                                    } catch (GitLabApiException e) {
+                                        if (e.getHttpStatus() == 404) {
+                                            listener.getLogger()
+                                                    .format(
+                                                            "%nIgnoring merge requests as source project not found, Please check permission on source repo...%n");
+                                            continue;
+                                        } else {
+                                            throw e;
+                                        }
+                                    }
+                                } else if (fork) {
+                                    originProjectPath = forkMrSources.get(mr.getSourceProjectId());
+                                }
+                                String targetSha;
+                                try {
+                                    targetSha = gitLabApi
+                                            .getRepositoryApi()
+                                            .getBranch(mr.getTargetProjectId(), mr.getTargetBranch())
+                                            .getCommit()
+                                            .getId();
+                                } catch (Exception e) {
+                                    listener.getLogger()
+                                            .format(
+                                                    "Failed getting TargetBranch from Merge Request: " + mr.getIid()
+                                                            + " ("
+                                                            + mr.getTitle() + ")%n%s",
+                                                    e);
+                                    continue;
+                                }
+                                LOGGER.log(
+                                        Level.FINE,
+                                        String.format(
+                                                "%s -> %s",
+                                                originOwner,
+                                                (request.isMember(originOwner) ? "Trusted" : "Untrusted")));
+                                for (ChangeRequestCheckoutStrategy strategy : strategies.get(fork)) {
+                                    if (request.process(
+                                            new MergeRequestSCMHead(
+                                                    "MR-" + mr.getIid()
+                                                            + (strategies
+                                                                                    .get(fork)
+                                                                                    .size()
+                                                                            > 1
+                                                                    ? "-"
+                                                                            + strategy.name()
+                                                                                    .toLowerCase(Locale.ENGLISH)
+                                                                    : ""),
+                                                    mr.getIid(),
+                                                    new BranchSCMHead(mr.getTargetBranch()),
+                                                    strategy,
+                                                    fork
+                                                            ? new SCMHeadOrigin.Fork(originProjectPath)
+                                                            : SCMHeadOrigin.DEFAULT,
+                                                    originOwner,
+                                                    originProjectPath,
+                                                    mr.getSourceBranch(),
+                                                    mr.getTitle()),
+                                            (SCMSourceRequest.RevisionLambda<
+                                                            MergeRequestSCMHead, MergeRequestSCMRevision>)
+                                                    head -> new MergeRequestSCMRevision(
+                                                            head,
+                                                            new BranchSCMRevision(
+                                                                    head.getTarget(),
+                                                                    targetSha // Latest revision of target branch
+                                                                    ),
+                                                            new BranchSCMRevision(
+                                                                    new BranchSCMHead(head.getOriginName()),
+                                                                    mr.getSha())),
+                                            new SCMSourceRequest.ProbeLambda<
+                                                    MergeRequestSCMHead, MergeRequestSCMRevision>() {
+                                                @NonNull
+                                                @Override
+                                                public SCMSourceCriteria.Probe create(
+                                                        @NonNull MergeRequestSCMHead head,
+                                                        @Nullable MergeRequestSCMRevision revision)
+                                                        throws IOException, InterruptedException {
+                                                    boolean isTrusted = request.isTrusted(head);
+                                                    if (!isTrusted) {
+                                                        listener.getLogger().format("(not from a trusted source)%n");
+                                                    }
+                                                    return createProbe(isTrusted ? head : head.getTarget(), revision);
+                                                }
+                                            },
+                                            (SCMSourceRequest.Witness) (head, revision, isMatch) -> {
+                                                if (isMatch) {
+                                                    listener.getLogger().format("Met criteria%n");
+                                                } else {
+                                                    listener.getLogger().format("Does not meet criteria%n");
+                                                }
+                                            })) {
+                                        listener.getLogger()
+                                                .format(
+                                                        "%n%d merge requests were processed (query completed)%n",
+                                                        count);
+                                        return;
+                                    }
+                                }
                             }
+                            listener.getLogger().format("%n%d merge requests were processed%n", count);
                         }
-                    }
-                    listener.getLogger().format("%n%d merge requests were processed%n", count);
-                }
-                if (request.isFetchTags()) {
-                    int count = 0;
-                    listener.getLogger().format("%nChecking tags..%n");
-                    Iterable<Tag> tags = request.getTags();
-                    for (Tag tag : tags) {
-                        count++;
-                        String tagName = tag.getName();
-                        Long tagDate = tag.getCommit().getCommittedDate().getTime();
-                        String sha = tag.getCommit().getId();
-                        listener.getLogger()
-                                .format(
-                                        "%nChecking tag %s%n",
-                                        HyperlinkNote.encodeTo(
-                                                tagUriTemplate(gitlabProject.getWebUrl())
-                                                        .set("tag", splitPath(tag.getName()))
-                                                        .expand(),
-                                                tag.getName()));
-                        GitLabTagSCMHead head = new GitLabTagSCMHead(tagName, tagDate);
-                        if (request.process(
-                                head,
-                                new GitTagSCMRevision(head, sha),
-                                new SCMSourceRequest.ProbeLambda<GitLabTagSCMHead, GitTagSCMRevision>() {
-                                    @NonNull
-                                    @Override
-                                    public SCMSourceCriteria.Probe create(
-                                            @NonNull GitLabTagSCMHead head, @Nullable GitTagSCMRevision revision)
-                                            throws IOException {
-                                        return createProbe(head, revision);
-                                    }
-                                },
-                                (SCMSourceRequest.Witness) (head1, revision, isMatch) -> {
-                                    if (isMatch) {
-                                        listener.getLogger().format("Met criteria%n");
-                                    } else {
-                                        listener.getLogger().format("Does not meet criteria%n");
-                                    }
-                                })) {
+                        if (request.isFetchTags()) {
+                            int count = 0;
+                            listener.getLogger().format("%nChecking tags..%n");
+                            Iterable<Tag> tags = request.getTags();
+                            for (Tag tag : tags) {
+                                count++;
+                                String tagName = tag.getName();
+                                Long tagDate =
+                                        tag.getCommit().getCommittedDate().getTime();
+                                String sha = tag.getCommit().getId();
+                                listener.getLogger()
+                                        .format(
+                                                "%nChecking tag %s%n",
+                                                HyperlinkNote.encodeTo(
+                                                        tagUriTemplate(gitlabProject.getWebUrl())
+                                                                .set("tag", splitPath(tag.getName()))
+                                                                .expand(),
+                                                        tag.getName()));
+                                GitLabTagSCMHead head = new GitLabTagSCMHead(tagName, tagDate);
+                                if (request.process(
+                                        head,
+                                        new GitTagSCMRevision(head, sha),
+                                        new SCMSourceRequest.ProbeLambda<GitLabTagSCMHead, GitTagSCMRevision>() {
+                                            @NonNull
+                                            @Override
+                                            public SCMSourceCriteria.Probe create(
+                                                    @NonNull GitLabTagSCMHead head,
+                                                    @Nullable GitTagSCMRevision revision)
+                                                    throws IOException {
+                                                return createProbe(head, revision);
+                                            }
+                                        },
+                                        (SCMSourceRequest.Witness) (head1, revision, isMatch) -> {
+                                            if (isMatch) {
+                                                listener.getLogger().format("Met criteria%n");
+                                            } else {
+                                                listener.getLogger().format("Does not meet criteria%n");
+                                            }
+                                        })) {
+                                    listener.getLogger().format("%n%d tags were processed (query completed)%n", count);
+                                    return;
+                                }
+                            }
                             listener.getLogger().format("%n%d tags were processed (query completed)%n", count);
-                            return;
                         }
                     }
-                    listener.getLogger().format("%n%d tags were processed (query completed)%n", count);
+                } catch (GitLabApiException | IOException | InterruptedException e) {
+                    LOGGER.log(Level.WARNING, "Exception caught:" + e, e);
+                    throw new RuntimeException("Failed to fetch latest heads", e);
                 }
+            });
+
+            if (indexingTimeout != null && indexingTimeout > 0) {
+                future.get(indexingTimeout, TimeUnit.SECONDS);
+            } else {
+                future.get();
             }
-        } catch (GitLabApiException e) {
-            LOGGER.log(Level.WARNING, "Exception caught:" + e, e);
-            throw new IOException("Failed to fetch latest heads", e);
+
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            listener.getLogger().println("Operation timed out while fetching data from GitLab");
+            throw new IOException("Operation timed out while fetching data from GitLab", e);
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IOException("Failed to fetch data from GitLab", e);
         } finally {
+            executor.shutdown();
             SCMSourceOwner owner = this.getOwner();
             if (owner != null) {
                 owner.save();

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -776,9 +776,9 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     @Override
     protected List<Action> retrieveActions(@NonNull SCMHead head, SCMHeadEvent event, @NonNull TaskListener listener) {
         Object timeoutDisplay = (indexingTimeout != null && indexingTimeout > 0) ? indexingTimeout : "N/A";
-        listener.getLogger().println(
-            String.format("Starting Gitlab Indexing: #Gitlab Server: %s #Timeout: %s", serverName, timeoutDisplay)
-        );
+        listener.getLogger()
+                .println(String.format(
+                        "Starting Gitlab Indexing: #Gitlab Server: %s #Timeout: %s", serverName, timeoutDisplay));
 
         getGitlabProject();
         List<Action> result = new ArrayList<>();

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -232,9 +232,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     }
 
     protected Project getGitlabProject(GitLabApi gitLabApi) {
-
         if (gitlabProject == null) {
-
             ExecutorService executor = Executors.newSingleThreadExecutor();
 
             Future<?> future = executor.submit(() -> {
@@ -777,13 +775,10 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     @NonNull
     @Override
     protected List<Action> retrieveActions(@NonNull SCMHead head, SCMHeadEvent event, @NonNull TaskListener listener) {
-        if (indexingTimeout != null && indexingTimeout > 0) {
-            listener.getLogger()
-                    .println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: "
-                            + indexingTimeout);
-        } else {
-            listener.getLogger().println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: N/A");
-        }
+        Object timeoutDisplay = (indexingTimeout != null && indexingTimeout > 0) ? indexingTimeout : "N/A";
+        listener.getLogger().println(
+            String.format("Starting Gitlab Indexing: #Gitlab Server: %s #Timeout: %s", serverName, timeoutDisplay)
+        );
 
         getGitlabProject();
         List<Action> result = new ArrayList<>();

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -232,15 +232,37 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     }
 
     protected Project getGitlabProject(GitLabApi gitLabApi) {
+
         if (gitlabProject == null) {
+
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+
+            Future<?> future = executor.submit(() -> {
+                try {
+                    gitlabProject = gitLabApi.getProjectApi().getProject(projectPath);
+                    sshRemote = gitlabProject.getSshUrlToRepo();
+                    httpRemote = gitlabProject.getHttpUrlToRepo();
+                    projectId = gitlabProject.getId();
+                } catch (GitLabApiException e) {
+                    throw new IllegalStateException("Failed to retrieve project " + projectPath, e);
+                }
+            });
+
             try {
-                gitlabProject = gitLabApi.getProjectApi().getProject(projectPath);
-                sshRemote = gitlabProject.getSshUrlToRepo();
-                httpRemote = gitlabProject.getHttpUrlToRepo();
-                projectId = gitlabProject.getId();
-            } catch (GitLabApiException e) {
-                throw new IllegalStateException("Failed to retrieve project " + projectPath, e);
+                if (indexingTimeout != null && indexingTimeout > 0) {
+                    future.get(indexingTimeout, TimeUnit.SECONDS);
+                } else {
+                     future.get();
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            } catch (TimeoutException e) {
+                future.cancel(true);
+                throw new RuntimeException("Operation timed out while fetching data from GitLab", e);
+            } catch (Exception e) {
+                throw e;
             }
+
         }
         return gitlabProject;
     }
@@ -318,13 +340,6 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_EXCEPTION")
     protected SCMRevision retrieve(@NonNull SCMHead head, @NonNull TaskListener listener)
             throws IOException, InterruptedException {
-        if (indexingTimeout != null && indexingTimeout > 0) {
-            listener.getLogger()
-                    .println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: "
-                            + indexingTimeout);
-        } else {
-            listener.getLogger().println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: N/A");
-        }
         ExecutorService executor = Executors.newSingleThreadExecutor();
         Future<SCMRevision> future = null;
         try {
@@ -411,14 +426,6 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             SCMHeadEvent<?> event,
             @NonNull TaskListener listener)
             throws IOException, InterruptedException {
-
-        if (indexingTimeout != null && indexingTimeout > 0) {
-            listener.getLogger()
-                    .println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: "
-                            + indexingTimeout);
-        } else {
-            listener.getLogger().println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: N/A");
-        }
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
         Future<?> future = null;
@@ -746,6 +753,14 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     @NonNull
     @Override
     protected List<Action> retrieveActions(SCMSourceEvent event, @NonNull TaskListener listener) {
+        if (indexingTimeout != null && indexingTimeout > 0) {
+            listener.getLogger()
+                .println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: "
+                    + indexingTimeout);
+        } else {
+            listener.getLogger().println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: N/A");
+        }
+
         List<Action> result = new ArrayList<>();
         getGitlabProject();
         GitLabSCMSourceContext ctx = new GitLabSCMSourceContext(null, SCMHeadObserver.none()).withTraits(traits);
@@ -763,6 +778,14 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     @NonNull
     @Override
     protected List<Action> retrieveActions(@NonNull SCMHead head, SCMHeadEvent event, @NonNull TaskListener listener) {
+        if (indexingTimeout != null && indexingTimeout > 0) {
+            listener.getLogger()
+                .println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: "
+                    + indexingTimeout);
+        } else {
+            listener.getLogger().println("Starting Gitlab Indexing: #Gitlab Server: " + serverName + " #Timeout: N/A");
+        }
+
         getGitlabProject();
         List<Action> result = new ArrayList<>();
         if (head instanceof BranchSCMHead) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -315,6 +315,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     }
 
     @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_EXCEPTION")
     protected SCMRevision retrieve(@NonNull SCMHead head, @NonNull TaskListener listener)
             throws IOException, InterruptedException {
         if (indexingTimeout != null && indexingTimeout > 0) {
@@ -403,6 +404,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     }
 
     @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_EXCEPTION")
     protected void retrieve(
             SCMSourceCriteria criteria,
             @NonNull SCMHeadObserver observer,

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -29,6 +29,7 @@ import hudson.model.Queue;
 import hudson.model.TaskListener;
 import hudson.scm.SCM;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabAvatar;
 import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabLink;
@@ -112,6 +113,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.springframework.security.core.Authentication;
 
 public class GitLabSCMSource extends AbstractGitSCMSource {
 
@@ -234,13 +236,16 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     protected Project getGitlabProject(GitLabApi gitLabApi) {
         if (gitlabProject == null) {
             ExecutorService executor = Executors.newSingleThreadExecutor();
+            Authentication auth = Jenkins.getAuthentication2();
 
             Future<?> future = executor.submit(() -> {
                 try {
-                    gitlabProject = gitLabApi.getProjectApi().getProject(projectPath);
-                    sshRemote = gitlabProject.getSshUrlToRepo();
-                    httpRemote = gitlabProject.getHttpUrlToRepo();
-                    projectId = gitlabProject.getId();
+                    try (ACLContext aclCtx = ACL.as2(auth)) {
+                        gitlabProject = gitLabApi.getProjectApi().getProject(projectPath);
+                        sshRemote = gitlabProject.getSshUrlToRepo();
+                        httpRemote = gitlabProject.getHttpUrlToRepo();
+                        projectId = gitlabProject.getId();
+                    }
                 } catch (GitLabApiException e) {
                     throw new IllegalStateException("Failed to retrieve project " + projectPath, e);
                 }
@@ -339,58 +344,65 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             throws IOException, InterruptedException {
         ExecutorService executor = Executors.newSingleThreadExecutor();
         Future<SCMRevision> future = null;
+        Authentication auth = Jenkins.getAuthentication2();
         try {
             future = executor.submit(() -> {
                 try {
-                    GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName, credentialsId);
-                    getGitlabProject(gitLabApi);
-                    if (head instanceof BranchSCMHead) {
-                        listener.getLogger().format("Querying the current revision of branch %s...%n", head.getName());
-                        String revision = gitLabApi
-                                .getRepositoryApi()
-                                .getBranch(gitlabProject, head.getName())
-                                .getCommit()
-                                .getId();
-                        listener.getLogger().format("Current revision of branch %s is %s%n", head.getName(), revision);
-                        return new BranchSCMRevision((BranchSCMHead) head, revision);
-                    } else if (head instanceof MergeRequestSCMHead) {
-                        MergeRequestSCMHead h = (MergeRequestSCMHead) head;
-                        listener.getLogger()
-                                .format("Querying the current revision of merge request #%s...%n", h.getId());
-                        MergeRequest mr = gitLabApi
-                                .getMergeRequestApi()
-                                .getMergeRequest(gitlabProject, Long.parseLong(h.getId()));
-                        String targetSha = gitLabApi
-                                .getRepositoryApi()
-                                .getBranch(mr.getTargetProjectId(), mr.getTargetBranch())
-                                .getCommit()
-                                .getId();
-                        if (mr.getState().equals(Constants.MergeRequestState.OPENED.toString())) {
+                    try (ACLContext aclCtx = ACL.as2(auth)) {
+                        GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName, credentialsId);
+                        getGitlabProject(gitLabApi);
+                        if (head instanceof BranchSCMHead) {
                             listener.getLogger()
-                                    .format("Current revision of merge request #%s is %s%n", h.getId(), mr.getSha());
-                            return new MergeRequestSCMRevision(
-                                    h,
-                                    new BranchSCMRevision(h.getTarget(), targetSha),
-                                    new BranchSCMRevision(new BranchSCMHead(h.getOriginName()), mr.getSha()));
+                                    .format("Querying the current revision of branch %s...%n", head.getName());
+                            String revision = gitLabApi
+                                    .getRepositoryApi()
+                                    .getBranch(gitlabProject, head.getName())
+                                    .getCommit()
+                                    .getId();
+                            listener.getLogger()
+                                    .format("Current revision of branch %s is %s%n", head.getName(), revision);
+                            return new BranchSCMRevision((BranchSCMHead) head, revision);
+                        } else if (head instanceof MergeRequestSCMHead) {
+                            MergeRequestSCMHead h = (MergeRequestSCMHead) head;
+                            listener.getLogger()
+                                    .format("Querying the current revision of merge request #%s...%n", h.getId());
+                            MergeRequest mr = gitLabApi
+                                    .getMergeRequestApi()
+                                    .getMergeRequest(gitlabProject, Long.parseLong(h.getId()));
+                            String targetSha = gitLabApi
+                                    .getRepositoryApi()
+                                    .getBranch(mr.getTargetProjectId(), mr.getTargetBranch())
+                                    .getCommit()
+                                    .getId();
+                            if (mr.getState().equals(Constants.MergeRequestState.OPENED.toString())) {
+                                listener.getLogger()
+                                        .format(
+                                                "Current revision of merge request #%s is %s%n",
+                                                h.getId(), mr.getSha());
+                                return new MergeRequestSCMRevision(
+                                        h,
+                                        new BranchSCMRevision(h.getTarget(), targetSha),
+                                        new BranchSCMRevision(new BranchSCMHead(h.getOriginName()), mr.getSha()));
+                            } else {
+                                listener.getLogger().format("Merge request #%s is CLOSED%n", h.getId());
+                                return null;
+                            }
+                        } else if (head instanceof GitLabTagSCMHead) {
+                            listener.getLogger().format("Querying the current revision of tag %s...%n", head.getName());
+                            String revision = gitLabApi
+                                    .getTagsApi()
+                                    .getTag(gitlabProject, head.getName())
+                                    .getCommit()
+                                    .getId();
+                            listener.getLogger().format("Current revision of tag %s is %s%n", head.getName(), revision);
+                            return new GitTagSCMRevision((GitLabTagSCMHead) head, revision);
                         } else {
-                            listener.getLogger().format("Merge request #%s is CLOSED%n", h.getId());
+                            listener.getLogger()
+                                    .format(
+                                            "Unknown head: %s of type %s%n",
+                                            head.getName(), head.getClass().getName());
                             return null;
                         }
-                    } else if (head instanceof GitLabTagSCMHead) {
-                        listener.getLogger().format("Querying the current revision of tag %s...%n", head.getName());
-                        String revision = gitLabApi
-                                .getTagsApi()
-                                .getTag(gitlabProject, head.getName())
-                                .getCommit()
-                                .getId();
-                        listener.getLogger().format("Current revision of tag %s is %s%n", head.getName(), revision);
-                        return new GitTagSCMRevision((GitLabTagSCMHead) head, revision);
-                    } else {
-                        listener.getLogger()
-                                .format(
-                                        "Unknown head: %s of type %s%n",
-                                        head.getName(), head.getClass().getName());
-                        return null;
                     }
                 } catch (GitLabApiException e) {
                     LOGGER.log(Level.WARNING, "Exception caught:" + e, e);
@@ -427,215 +439,87 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         ExecutorService executor = Executors.newSingleThreadExecutor();
         Future<?> future = null;
         try {
-
+            Authentication auth = Jenkins.getAuthentication2();
             future = executor.submit(() -> {
                 try {
-                    GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName, credentialsId);
-                    getGitlabProject(gitLabApi);
-                    GitLabSCMSourceContext ctx = new GitLabSCMSourceContext(criteria, observer).withTraits(getTraits());
-                    try (GitLabSCMSourceRequest request = ctx.newRequest(this, listener)) {
-                        request.setGitLabApi(gitLabApi);
-                        request.setProject(gitlabProject);
-                        request.setMembers(getMembers());
-                        if (request.isFetchBranches()) {
-                            request.setBranches(gitLabApi.getRepositoryApi().getBranches(gitlabProject));
-                        }
-                        boolean mergeRequestsEnabled = !Boolean.FALSE.equals(gitlabProject.getMergeRequestsEnabled());
-                        if (request.isFetchMRs() && mergeRequestsEnabled) {
-                            final boolean forkedFromProject = (gitlabProject.getForkedFromProject() != null);
-                            if (!ctx.buildMRForksNotMirror() && forkedFromProject) {
-                                listener.getLogger().format("%nIgnoring merge requests as project is a mirror...%n");
-                            } else {
-                                // If not authenticated GitLabApi cannot detect if it is a fork
-                                // If `forkedFromProject` is false it doesn't mean anything
-                                listener.getLogger()
-                                        .format(
-                                                !forkedFromProject
-                                                        ? "%nUnable to detect if it is a mirror or not still fetching MRs anyway...%n"
-                                                        : "%nCollecting MRs for fork except those that target its upstream...%n");
-                                Stream<MergeRequest> mrs = gitLabApi
-                                        .getMergeRequestApi()
-                                        .getMergeRequests(gitlabProject, MergeRequestState.OPENED)
-                                        .stream()
-                                        .filter(mr -> mr.getSourceProjectId() != null);
-                                // Patch for issue 453 - avoid an NPE if this isn't a forked project
-                                if (ctx.buildMRForksNotMirror() && forkedFromProject) {
-                                    mrs = mrs.filter(mr -> !mr.getTargetProjectId()
-                                            .equals(gitlabProject
-                                                    .getForkedFromProject()
-                                                    .getId()));
-                                }
-
-                                if (ctx.alwaysIgnoreMRWorkInProgress()) {
-                                    mrs = mrs.filter(mr -> !mr.getWorkInProgress());
-                                }
-
-                                request.setMergeRequests(mrs.collect(Collectors.toList()));
+                    try (ACLContext aclCtx = ACL.as2(auth)) {
+                        GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName, credentialsId);
+                        getGitlabProject(gitLabApi);
+                        GitLabSCMSourceContext ctx =
+                                new GitLabSCMSourceContext(criteria, observer).withTraits(getTraits());
+                        try (GitLabSCMSourceRequest request = ctx.newRequest(this, listener)) {
+                            request.setGitLabApi(gitLabApi);
+                            request.setProject(gitlabProject);
+                            request.setMembers(getMembers());
+                            if (request.isFetchBranches()) {
+                                request.setBranches(gitLabApi.getRepositoryApi().getBranches(gitlabProject));
                             }
-                        }
-                        if (request.isFetchTags()) {
-                            request.setTags(gitLabApi.getTagsApi().getTags(gitlabProject));
-                        }
-                        if (request.isFetchBranches()) {
-                            int count = 0;
-                            listener.getLogger().format("%nChecking branches.. %n");
-                            Iterable<Branch> branches = request.getBranches();
-                            for (final Branch branch : branches) {
-                                count++;
-                                String branchName = branch.getName();
-                                String sha = branch.getCommit().getId();
-                                listener.getLogger()
-                                        .format(
-                                                "%nChecking branch %s%n",
-                                                HyperlinkNote.encodeTo(
-                                                        branchUriTemplate(gitlabProject.getWebUrl())
-                                                                .set("branch", splitPath(branchName))
-                                                                .expand(),
-                                                        branchName));
-                                if (request.process(
-                                        new BranchSCMHead(branchName),
-                                        (SCMSourceRequest.RevisionLambda<BranchSCMHead, BranchSCMRevision>)
-                                                head -> new BranchSCMRevision(head, sha),
-                                        new SCMSourceRequest.ProbeLambda<BranchSCMHead, BranchSCMRevision>() {
-                                            @NonNull
-                                            @Override
-                                            public SCMSourceCriteria.Probe create(
-                                                    @NonNull BranchSCMHead head, @Nullable BranchSCMRevision revision)
-                                                    throws IOException {
-                                                return createProbe(head, revision);
-                                            }
-                                        },
-                                        (SCMSourceRequest.Witness) (head, revision, isMatch) -> {
-                                            if (isMatch) {
-                                                listener.getLogger().format("Met criteria%n");
-                                            } else {
-                                                listener.getLogger().format("Does not meet criteria%n");
-                                            }
-                                        })) {
+                            boolean mergeRequestsEnabled =
+                                    !Boolean.FALSE.equals(gitlabProject.getMergeRequestsEnabled());
+                            if (request.isFetchMRs() && mergeRequestsEnabled) {
+                                final boolean forkedFromProject = (gitlabProject.getForkedFromProject() != null);
+                                if (!ctx.buildMRForksNotMirror() && forkedFromProject) {
                                     listener.getLogger()
-                                            .format("%n%d branches were processed (query completed)%n", count);
-                                    return;
-                                }
-                            }
-                            listener.getLogger().format("%n%d branches were processed%n", count);
-                        }
-                        if (request.isFetchMRs() && !request.isComplete() && mergeRequestsEnabled) {
-                            int count = 0;
-                            listener.getLogger().format("%nChecking merge requests..%n");
-                            HashMap<Long, String> forkMrSources = new HashMap<>();
-                            for (MergeRequest mr : request.getMergeRequests()) {
-                                mergeRequestContributorCache.put(
-                                        mr.getIid(),
-                                        new ContributorMetadataAction(
-                                                mr.getAuthor().getUsername(),
-                                                mr.getAuthor().getName(),
-                                                mr.getAuthor().getEmail()));
-                                mergeRequestMetadataCache.put(
-                                        mr.getIid(),
-                                        new ObjectMetadataAction(mr.getTitle(), mr.getDescription(), mr.getWebUrl()));
-                                count++;
-                                listener.getLogger()
-                                        .format(
-                                                "%nChecking merge request %s%n",
-                                                HyperlinkNote.encodeTo(
-                                                        mergeRequestUriTemplate(gitlabProject.getWebUrl())
-                                                                .set("iid", mr.getIid())
-                                                                .expand(),
-                                                        "!" + mr.getIid()));
-                                Map<Boolean, Set<ChangeRequestCheckoutStrategy>> strategies = request.getMRStrategies();
-                                boolean fork = !mr.getSourceProjectId().equals(mr.getTargetProjectId());
-                                String originOwner = mr.getAuthor().getUsername();
-                                String originProjectPath = projectPath;
-                                if (fork && !forkMrSources.containsKey(mr.getSourceProjectId())) {
-                                    // This is a hack to get the path with namespace of source project for forked
-                                    // mrs
-                                    try {
-                                        originProjectPath = gitLabApi
-                                                .getProjectApi()
-                                                .getProject(mr.getSourceProjectId())
-                                                .getPathWithNamespace();
-                                        forkMrSources.put(mr.getSourceProjectId(), originProjectPath);
-                                    } catch (GitLabApiException e) {
-                                        if (e.getHttpStatus() == 404) {
-                                            listener.getLogger()
-                                                    .format(
-                                                            "%nIgnoring merge requests as source project not found, Please check permission on source repo...%n");
-                                            continue;
-                                        } else {
-                                            throw e;
-                                        }
-                                    }
-                                } else if (fork) {
-                                    originProjectPath = forkMrSources.get(mr.getSourceProjectId());
-                                }
-                                String targetSha;
-                                try {
-                                    targetSha = gitLabApi
-                                            .getRepositoryApi()
-                                            .getBranch(mr.getTargetProjectId(), mr.getTargetBranch())
-                                            .getCommit()
-                                            .getId();
-                                } catch (Exception e) {
+                                            .format("%nIgnoring merge requests as project is a mirror...%n");
+                                } else {
+                                    // If not authenticated GitLabApi cannot detect if it is a fork
+                                    // If `forkedFromProject` is false it doesn't mean anything
                                     listener.getLogger()
                                             .format(
-                                                    "Failed getting TargetBranch from Merge Request: " + mr.getIid()
-                                                            + " ("
-                                                            + mr.getTitle() + ")%n%s",
-                                                    e);
-                                    continue;
+                                                    !forkedFromProject
+                                                            ? "%nUnable to detect if it is a mirror or not still fetching MRs anyway...%n"
+                                                            : "%nCollecting MRs for fork except those that target its upstream...%n");
+                                    Stream<MergeRequest> mrs = gitLabApi
+                                            .getMergeRequestApi()
+                                            .getMergeRequests(gitlabProject, MergeRequestState.OPENED)
+                                            .stream()
+                                            .filter(mr -> mr.getSourceProjectId() != null);
+                                    // Patch for issue 453 - avoid an NPE if this isn't a forked project
+                                    if (ctx.buildMRForksNotMirror() && forkedFromProject) {
+                                        mrs = mrs.filter(mr -> !mr.getTargetProjectId()
+                                                .equals(gitlabProject
+                                                        .getForkedFromProject()
+                                                        .getId()));
+                                    }
+
+                                    if (ctx.alwaysIgnoreMRWorkInProgress()) {
+                                        mrs = mrs.filter(mr -> !mr.getWorkInProgress());
+                                    }
+
+                                    request.setMergeRequests(mrs.collect(Collectors.toList()));
                                 }
-                                LOGGER.log(
-                                        Level.FINE,
-                                        String.format(
-                                                "%s -> %s",
-                                                originOwner,
-                                                (request.isMember(originOwner) ? "Trusted" : "Untrusted")));
-                                for (ChangeRequestCheckoutStrategy strategy : strategies.get(fork)) {
+                            }
+                            if (request.isFetchTags()) {
+                                request.setTags(gitLabApi.getTagsApi().getTags(gitlabProject));
+                            }
+                            if (request.isFetchBranches()) {
+                                int count = 0;
+                                listener.getLogger().format("%nChecking branches.. %n");
+                                Iterable<Branch> branches = request.getBranches();
+                                for (final Branch branch : branches) {
+                                    count++;
+                                    String branchName = branch.getName();
+                                    String sha = branch.getCommit().getId();
+                                    listener.getLogger()
+                                            .format(
+                                                    "%nChecking branch %s%n",
+                                                    HyperlinkNote.encodeTo(
+                                                            branchUriTemplate(gitlabProject.getWebUrl())
+                                                                    .set("branch", splitPath(branchName))
+                                                                    .expand(),
+                                                            branchName));
                                     if (request.process(
-                                            new MergeRequestSCMHead(
-                                                    "MR-" + mr.getIid()
-                                                            + (strategies
-                                                                                    .get(fork)
-                                                                                    .size()
-                                                                            > 1
-                                                                    ? "-"
-                                                                            + strategy.name()
-                                                                                    .toLowerCase(Locale.ENGLISH)
-                                                                    : ""),
-                                                    mr.getIid(),
-                                                    new BranchSCMHead(mr.getTargetBranch()),
-                                                    strategy,
-                                                    fork
-                                                            ? new SCMHeadOrigin.Fork(originProjectPath)
-                                                            : SCMHeadOrigin.DEFAULT,
-                                                    originOwner,
-                                                    originProjectPath,
-                                                    mr.getSourceBranch(),
-                                                    mr.getTitle()),
-                                            (SCMSourceRequest.RevisionLambda<
-                                                            MergeRequestSCMHead, MergeRequestSCMRevision>)
-                                                    head -> new MergeRequestSCMRevision(
-                                                            head,
-                                                            new BranchSCMRevision(
-                                                                    head.getTarget(),
-                                                                    targetSha // Latest revision of target branch
-                                                                    ),
-                                                            new BranchSCMRevision(
-                                                                    new BranchSCMHead(head.getOriginName()),
-                                                                    mr.getSha())),
-                                            new SCMSourceRequest.ProbeLambda<
-                                                    MergeRequestSCMHead, MergeRequestSCMRevision>() {
+                                            new BranchSCMHead(branchName),
+                                            (SCMSourceRequest.RevisionLambda<BranchSCMHead, BranchSCMRevision>)
+                                                    head -> new BranchSCMRevision(head, sha),
+                                            new SCMSourceRequest.ProbeLambda<BranchSCMHead, BranchSCMRevision>() {
                                                 @NonNull
                                                 @Override
                                                 public SCMSourceCriteria.Probe create(
-                                                        @NonNull MergeRequestSCMHead head,
-                                                        @Nullable MergeRequestSCMRevision revision)
-                                                        throws IOException, InterruptedException {
-                                                    boolean isTrusted = request.isTrusted(head);
-                                                    if (!isTrusted) {
-                                                        listener.getLogger().format("(not from a trusted source)%n");
-                                                    }
-                                                    return createProbe(isTrusted ? head : head.getTarget(), revision);
+                                                        @NonNull BranchSCMHead head,
+                                                        @Nullable BranchSCMRevision revision)
+                                                        throws IOException {
+                                                    return createProbe(head, revision);
                                                 }
                                             },
                                             (SCMSourceRequest.Witness) (head, revision, isMatch) -> {
@@ -646,59 +530,198 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                                                 }
                                             })) {
                                         listener.getLogger()
-                                                .format(
-                                                        "%n%d merge requests were processed (query completed)%n",
-                                                        count);
+                                                .format("%n%d branches were processed (query completed)%n", count);
                                         return;
                                     }
                                 }
+                                listener.getLogger().format("%n%d branches were processed%n", count);
                             }
-                            listener.getLogger().format("%n%d merge requests were processed%n", count);
-                        }
-                        if (request.isFetchTags()) {
-                            int count = 0;
-                            listener.getLogger().format("%nChecking tags..%n");
-                            Iterable<Tag> tags = request.getTags();
-                            for (Tag tag : tags) {
-                                count++;
-                                String tagName = tag.getName();
-                                Long tagDate =
-                                        tag.getCommit().getCommittedDate().getTime();
-                                String sha = tag.getCommit().getId();
-                                listener.getLogger()
-                                        .format(
-                                                "%nChecking tag %s%n",
-                                                HyperlinkNote.encodeTo(
-                                                        tagUriTemplate(gitlabProject.getWebUrl())
-                                                                .set("tag", splitPath(tag.getName()))
-                                                                .expand(),
-                                                        tag.getName()));
-                                GitLabTagSCMHead head = new GitLabTagSCMHead(tagName, tagDate);
-                                if (request.process(
-                                        head,
-                                        new GitTagSCMRevision(head, sha),
-                                        new SCMSourceRequest.ProbeLambda<GitLabTagSCMHead, GitTagSCMRevision>() {
-                                            @NonNull
-                                            @Override
-                                            public SCMSourceCriteria.Probe create(
-                                                    @NonNull GitLabTagSCMHead head,
-                                                    @Nullable GitTagSCMRevision revision)
-                                                    throws IOException {
-                                                return createProbe(head, revision);
-                                            }
-                                        },
-                                        (SCMSourceRequest.Witness) (head1, revision, isMatch) -> {
-                                            if (isMatch) {
-                                                listener.getLogger().format("Met criteria%n");
+                            if (request.isFetchMRs() && !request.isComplete() && mergeRequestsEnabled) {
+                                int count = 0;
+                                listener.getLogger().format("%nChecking merge requests..%n");
+                                HashMap<Long, String> forkMrSources = new HashMap<>();
+                                for (MergeRequest mr : request.getMergeRequests()) {
+                                    mergeRequestContributorCache.put(
+                                            mr.getIid(),
+                                            new ContributorMetadataAction(
+                                                    mr.getAuthor().getUsername(),
+                                                    mr.getAuthor().getName(),
+                                                    mr.getAuthor().getEmail()));
+                                    mergeRequestMetadataCache.put(
+                                            mr.getIid(),
+                                            new ObjectMetadataAction(
+                                                    mr.getTitle(), mr.getDescription(), mr.getWebUrl()));
+                                    count++;
+                                    listener.getLogger()
+                                            .format(
+                                                    "%nChecking merge request %s%n",
+                                                    HyperlinkNote.encodeTo(
+                                                            mergeRequestUriTemplate(gitlabProject.getWebUrl())
+                                                                    .set("iid", mr.getIid())
+                                                                    .expand(),
+                                                            "!" + mr.getIid()));
+                                    Map<Boolean, Set<ChangeRequestCheckoutStrategy>> strategies =
+                                            request.getMRStrategies();
+                                    boolean fork = !mr.getSourceProjectId().equals(mr.getTargetProjectId());
+                                    String originOwner = mr.getAuthor().getUsername();
+                                    String originProjectPath = projectPath;
+                                    if (fork && !forkMrSources.containsKey(mr.getSourceProjectId())) {
+                                        // This is a hack to get the path with namespace of source project for forked
+                                        // mrs
+                                        try {
+                                            originProjectPath = gitLabApi
+                                                    .getProjectApi()
+                                                    .getProject(mr.getSourceProjectId())
+                                                    .getPathWithNamespace();
+                                            forkMrSources.put(mr.getSourceProjectId(), originProjectPath);
+                                        } catch (GitLabApiException e) {
+                                            if (e.getHttpStatus() == 404) {
+                                                listener.getLogger()
+                                                        .format(
+                                                                "%nIgnoring merge requests as source project not found, Please check permission on source repo...%n");
+                                                continue;
                                             } else {
-                                                listener.getLogger().format("Does not meet criteria%n");
+                                                throw e;
                                             }
-                                        })) {
-                                    listener.getLogger().format("%n%d tags were processed (query completed)%n", count);
-                                    return;
+                                        }
+                                    } else if (fork) {
+                                        originProjectPath = forkMrSources.get(mr.getSourceProjectId());
+                                    }
+                                    String targetSha;
+                                    try {
+                                        targetSha = gitLabApi
+                                                .getRepositoryApi()
+                                                .getBranch(mr.getTargetProjectId(), mr.getTargetBranch())
+                                                .getCommit()
+                                                .getId();
+                                    } catch (Exception e) {
+                                        listener.getLogger()
+                                                .format(
+                                                        "Failed getting TargetBranch from Merge Request: " + mr.getIid()
+                                                                + " ("
+                                                                + mr.getTitle() + ")%n%s",
+                                                        e);
+                                        continue;
+                                    }
+                                    LOGGER.log(
+                                            Level.FINE,
+                                            String.format(
+                                                    "%s -> %s",
+                                                    originOwner,
+                                                    (request.isMember(originOwner) ? "Trusted" : "Untrusted")));
+                                    for (ChangeRequestCheckoutStrategy strategy : strategies.get(fork)) {
+                                        if (request.process(
+                                                new MergeRequestSCMHead(
+                                                        "MR-" + mr.getIid()
+                                                                + (strategies
+                                                                                        .get(fork)
+                                                                                        .size()
+                                                                                > 1
+                                                                        ? "-"
+                                                                                + strategy.name()
+                                                                                        .toLowerCase(Locale.ENGLISH)
+                                                                        : ""),
+                                                        mr.getIid(),
+                                                        new BranchSCMHead(mr.getTargetBranch()),
+                                                        strategy,
+                                                        fork
+                                                                ? new SCMHeadOrigin.Fork(originProjectPath)
+                                                                : SCMHeadOrigin.DEFAULT,
+                                                        originOwner,
+                                                        originProjectPath,
+                                                        mr.getSourceBranch(),
+                                                        mr.getTitle()),
+                                                (SCMSourceRequest.RevisionLambda<
+                                                                MergeRequestSCMHead, MergeRequestSCMRevision>)
+                                                        head -> new MergeRequestSCMRevision(
+                                                                head,
+                                                                new BranchSCMRevision(
+                                                                        head.getTarget(),
+                                                                        targetSha // Latest revision of target branch
+                                                                        ),
+                                                                new BranchSCMRevision(
+                                                                        new BranchSCMHead(head.getOriginName()),
+                                                                        mr.getSha())),
+                                                new SCMSourceRequest.ProbeLambda<
+                                                        MergeRequestSCMHead, MergeRequestSCMRevision>() {
+                                                    @NonNull
+                                                    @Override
+                                                    public SCMSourceCriteria.Probe create(
+                                                            @NonNull MergeRequestSCMHead head,
+                                                            @Nullable MergeRequestSCMRevision revision)
+                                                            throws IOException, InterruptedException {
+                                                        boolean isTrusted = request.isTrusted(head);
+                                                        if (!isTrusted) {
+                                                            listener.getLogger()
+                                                                    .format("(not from a trusted source)%n");
+                                                        }
+                                                        return createProbe(
+                                                                isTrusted ? head : head.getTarget(), revision);
+                                                    }
+                                                },
+                                                (SCMSourceRequest.Witness) (head, revision, isMatch) -> {
+                                                    if (isMatch) {
+                                                        listener.getLogger().format("Met criteria%n");
+                                                    } else {
+                                                        listener.getLogger().format("Does not meet criteria%n");
+                                                    }
+                                                })) {
+                                            listener.getLogger()
+                                                    .format(
+                                                            "%n%d merge requests were processed (query completed)%n",
+                                                            count);
+                                            return;
+                                        }
+                                    }
                                 }
+                                listener.getLogger().format("%n%d merge requests were processed%n", count);
                             }
-                            listener.getLogger().format("%n%d tags were processed (query completed)%n", count);
+                            if (request.isFetchTags()) {
+                                int count = 0;
+                                listener.getLogger().format("%nChecking tags..%n");
+                                Iterable<Tag> tags = request.getTags();
+                                for (Tag tag : tags) {
+                                    count++;
+                                    String tagName = tag.getName();
+                                    Long tagDate =
+                                            tag.getCommit().getCommittedDate().getTime();
+                                    String sha = tag.getCommit().getId();
+                                    listener.getLogger()
+                                            .format(
+                                                    "%nChecking tag %s%n",
+                                                    HyperlinkNote.encodeTo(
+                                                            tagUriTemplate(gitlabProject.getWebUrl())
+                                                                    .set("tag", splitPath(tag.getName()))
+                                                                    .expand(),
+                                                            tag.getName()));
+                                    GitLabTagSCMHead head = new GitLabTagSCMHead(tagName, tagDate);
+                                    if (request.process(
+                                            head,
+                                            new GitTagSCMRevision(head, sha),
+                                            new SCMSourceRequest.ProbeLambda<GitLabTagSCMHead, GitTagSCMRevision>() {
+                                                @NonNull
+                                                @Override
+                                                public SCMSourceCriteria.Probe create(
+                                                        @NonNull GitLabTagSCMHead head,
+                                                        @Nullable GitTagSCMRevision revision)
+                                                        throws IOException {
+                                                    return createProbe(head, revision);
+                                                }
+                                            },
+                                            (SCMSourceRequest.Witness) (head1, revision, isMatch) -> {
+                                                if (isMatch) {
+                                                    listener.getLogger().format("Met criteria%n");
+                                                } else {
+                                                    listener.getLogger().format("Does not meet criteria%n");
+                                                }
+                                            })) {
+                                        listener.getLogger()
+                                                .format("%n%d tags were processed (query completed)%n", count);
+                                        return;
+                                    }
+                                }
+                                listener.getLogger().format("%n%d tags were processed (query completed)%n", count);
+                            }
                         }
                     }
                 } catch (GitLabApiException | IOException | InterruptedException e) {

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -171,6 +171,8 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
      *                      credentials to use for
      *                      GitLab Server Authentication to access GitLab APIs
      */
+    private Integer indexingTimeout = 3600;
+
     @DataBoundConstructor
     public GitLabServer(@NonNull String serverUrl, @NonNull String name, @NonNull String credentialsId) {
         this.serverUrl = defaultIfBlank(StringUtils.trim(serverUrl), GITLAB_SERVER_URL);
@@ -490,6 +492,16 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     @CheckForNull
     public Integer getHookTriggerDelay() {
         return this.hookTriggerDelay;
+    }
+
+    @CheckForNull
+    public Integer getIndexingTimeout() {
+        return indexingTimeout;
+    }
+
+    @DataBoundSetter
+    public void setIndexingTimeout(Integer indexingTimeout) {
+        this.indexingTimeout = indexingTimeout;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -171,8 +171,6 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
      *                      credentials to use for
      *                      GitLab Server Authentication to access GitLab APIs
      */
-    private Integer indexingTimeout = 3600;
-
     @DataBoundConstructor
     public GitLabServer(@NonNull String serverUrl, @NonNull String name, @NonNull String credentialsId) {
         this.serverUrl = defaultIfBlank(StringUtils.trim(serverUrl), GITLAB_SERVER_URL);
@@ -492,16 +490,6 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     @CheckForNull
     public Integer getHookTriggerDelay() {
         return this.hookTriggerDelay;
-    }
-
-    @CheckForNull
-    public Integer getIndexingTimeout() {
-        return indexingTimeout;
-    }
-
-    @DataBoundSetter
-    public void setIndexingTimeout(Integer indexingTimeout) {
-        this.indexingTimeout = indexingTimeout;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -274,11 +274,6 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
      */
     public StandardCredentials getCredentials(AccessControlled context) {
         Jenkins jenkins = Jenkins.get();
-        if (context == null) {
-            jenkins.checkPermission(CredentialsProvider.USE_OWN);
-        } else {
-            context.checkPermission(CredentialsProvider.USE_OWN);
-        }
         return StringUtils.isBlank(credentialsId)
                 ? null
                 : CredentialsMatchers.firstOrNull(
@@ -334,7 +329,6 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     public StringCredentials getWebhookSecretCredentials(AccessControlled context) {
         Jenkins jenkins = Jenkins.get();
         if (context == null) {
-            jenkins.checkPermission(CredentialsProvider.USE_OWN);
             return StringUtils.isBlank(webhookSecretCredentialsId)
                     ? null
                     : CredentialsMatchers.firstOrNull(
@@ -346,7 +340,6 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
                                             .build()),
                             withId(webhookSecretCredentialsId));
         } else {
-            context.checkPermission(CredentialsProvider.USE_OWN);
             if (context instanceof ItemGroup) {
                 return StringUtils.isBlank(webhookSecretCredentialsId)
                         ? null

--- a/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserverconfig/servers/GitLabServer.java
@@ -274,6 +274,11 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
      */
     public StandardCredentials getCredentials(AccessControlled context) {
         Jenkins jenkins = Jenkins.get();
+        if (context == null) {
+            jenkins.checkPermission(CredentialsProvider.USE_OWN);
+        } else {
+            context.checkPermission(CredentialsProvider.USE_OWN);
+        }
         return StringUtils.isBlank(credentialsId)
                 ? null
                 : CredentialsMatchers.firstOrNull(
@@ -329,6 +334,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     public StringCredentials getWebhookSecretCredentials(AccessControlled context) {
         Jenkins jenkins = Jenkins.get();
         if (context == null) {
+            jenkins.checkPermission(CredentialsProvider.USE_OWN);
             return StringUtils.isBlank(webhookSecretCredentialsId)
                     ? null
                     : CredentialsMatchers.firstOrNull(
@@ -340,6 +346,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
                                             .build()),
                             withId(webhookSecretCredentialsId));
         } else {
+            context.checkPermission(CredentialsProvider.USE_OWN);
             if (context instanceof ItemGroup) {
                 return StringUtils.isBlank(webhookSecretCredentialsId)
                         ? null

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
@@ -16,7 +16,29 @@
   <f:entry title="${%Behaviours}">
     <scm:traits field="traits"/>
   </f:entry>
+  <f:advanced title="${%Advanced}">
+    <f:entry title="${%Indexing Timeout}" description="Maximum time to index a repository (Seconds)">
+      <f:number clazz="indexing-timeout" field="indexingTimeout" default="0"/>
+    </f:entry>
+  </f:advanced>
   <f:invisibleEntry>
     <f:number clazz="project-id" field="projectId"/>
   </f:invisibleEntry>
+
+  <script>
+    // var projectOwner = document.getElementsByClassName('project-owner');
+    //
+    // var projectPath = document.getElementsByClassName('project-path');
+    //
+    // projectPath.addEventListener('change', function() {
+    //     var currentPath = projectPath.value;
+    //     for(var i = currentPath.length-1; i >= 0; i--) {
+    //         currentPath = currentPath.substring(0, currentPath.length-1);
+    //         if(currentPath[i] === '/') {
+    //             break;
+    //         }
+    //     }
+    //     projectOwner.item(0).value = currentPath;
+    // })
+  </script>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
@@ -24,21 +24,4 @@
   <f:invisibleEntry>
     <f:number clazz="project-id" field="projectId"/>
   </f:invisibleEntry>
-
-  <script>
-    // var projectOwner = document.getElementsByClassName('project-owner');
-    //
-    // var projectPath = document.getElementsByClassName('project-path');
-    //
-    // projectPath.addEventListener('change', function() {
-    //     var currentPath = projectPath.value;
-    //     for(var i = currentPath.length-1; i >= 0; i--) {
-    //         currentPath = currentPath.substring(0, currentPath.length-1);
-    //         if(currentPath[i] === '/') {
-    //             break;
-    //         }
-    //     }
-    //     projectOwner.item(0).value = currentPath;
-    // })
-  </script>
 </j:jelly>

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
@@ -4,36 +4,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 
-import com.google.common.util.concurrent.MoreExecutors;
-import hudson.model.TaskListener;
 import hudson.security.AccessControlled;
-import hudson.util.StreamTaskListener;
 import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper;
 import io.jenkins.plugins.gitlabbranchsource.helpers.Sleeper;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.Executors;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import jenkins.branch.BranchSource;
-import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSourceOwner;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
-import org.gitlab4j.api.MergeRequestApi;
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.Member;
-import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.ProjectApi;
-import org.gitlab4j.api.RepositoryApi;
-import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -46,7 +31,6 @@ import org.mockito.Mockito;
 public class GitLabSCMSourceTest {
 
     private static final String SERVER = "server";
-    private static final String PROJECT_NAME = "project";
     private static final String SOURCE_ID = "id";
 
     @ClassRule
@@ -66,37 +50,6 @@ public class GitLabSCMSourceTest {
     public void tearDown() {
         utilities.close();
         sleeperMockedConstruction.close();
-    }
-
-    @Test
-    public void retrieveMRWithEmptyProjectSettings() throws GitLabApiException, IOException, InterruptedException {
-        GitLabApi gitLabApi = Mockito.mock(GitLabApi.class);
-        ProjectApi projectApi = Mockito.mock(ProjectApi.class);
-        RepositoryApi repoApi = Mockito.mock(RepositoryApi.class);
-        MergeRequestApi mrApi = Mockito.mock(MergeRequestApi.class);
-        Mockito.when(gitLabApi.getProjectApi()).thenReturn(projectApi);
-        Mockito.when(gitLabApi.getMergeRequestApi()).thenReturn(mrApi);
-        Mockito.when(gitLabApi.getRepositoryApi()).thenReturn(repoApi);
-        Mockito.when(projectApi.getProject(any())).thenReturn(new Project());
-        try (MockedStatic<GitLabHelper> utilities = Mockito.mockStatic(GitLabHelper.class); MockedStatic<Executors> executorsMockedStatic = Mockito.mockStatic(Executors.class)) {
-            utilities
-                    .when(() -> GitLabHelper.apiBuilder(any(AccessControlled.class), anyString(), anyString()))
-                    .thenReturn(gitLabApi);
-            executorsMockedStatic.when(null).thenReturn(
-                MoreExecutors.directExecutor());
-            GitLabServers.get().addServer(new GitLabServer("", SERVER, ""));
-            GitLabSCMSourceBuilder sb =
-                    new GitLabSCMSourceBuilder(SOURCE_ID, SERVER, "creds", "po", "group/project", "project");
-            WorkflowMultiBranchProject project = j.createProject(WorkflowMultiBranchProject.class, PROJECT_NAME);
-            BranchSource source = new BranchSource(sb.build());
-            source.getSource()
-                    .setTraits(Arrays.asList(new BranchDiscoveryTrait(0), new OriginMergeRequestDiscoveryTrait(1)));
-            project.getSourcesList().add(source);
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            final TaskListener listener = new StreamTaskListener(out, StandardCharsets.UTF_8);
-            Set<SCMHead> scmHead = source.getSource().fetch(listener);
-            assertEquals(0, scmHead.size());
-        }
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
@@ -4,33 +4,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 
-import hudson.model.TaskListener;
 import hudson.security.AccessControlled;
-import hudson.util.StreamTaskListener;
 import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper;
 import io.jenkins.plugins.gitlabbranchsource.helpers.Sleeper;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import jenkins.branch.BranchSource;
-import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSourceOwner;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
-import org.gitlab4j.api.MergeRequestApi;
 import org.gitlab4j.api.ProjectApi;
-import org.gitlab4j.api.RepositoryApi;
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.Member;
-import org.gitlab4j.api.models.Project;
-import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -43,7 +30,6 @@ import org.mockito.Mockito;
 public class GitLabSCMSourceTest {
 
     private static final String SERVER = "server";
-    private static final String PROJECT_NAME = "project";
     private static final String SOURCE_ID = "id";
 
     @ClassRule
@@ -63,33 +49,6 @@ public class GitLabSCMSourceTest {
     public void tearDown() {
         utilities.close();
         sleeperMockedConstruction.close();
-    }
-
-    @Test
-    public void retrieveMRWithEmptyProjectSettings() throws GitLabApiException, IOException, InterruptedException {
-        GitLabApi gitLabApi = Mockito.mock(GitLabApi.class);
-        ProjectApi projectApi = Mockito.mock(ProjectApi.class);
-        RepositoryApi repoApi = Mockito.mock(RepositoryApi.class);
-        MergeRequestApi mrApi = Mockito.mock(MergeRequestApi.class);
-        Mockito.when(gitLabApi.getProjectApi()).thenReturn(projectApi);
-        Mockito.when(gitLabApi.getMergeRequestApi()).thenReturn(mrApi);
-        Mockito.when(gitLabApi.getRepositoryApi()).thenReturn(repoApi);
-        Mockito.when(projectApi.getProject(any())).thenReturn(new Project());
-        utilities
-                .when(() -> GitLabHelper.apiBuilder(any(AccessControlled.class), anyString(), anyString()))
-                .thenReturn(gitLabApi);
-        GitLabServers.get().addServer(new GitLabServer("", SERVER, ""));
-        GitLabSCMSourceBuilder sb =
-                new GitLabSCMSourceBuilder(SOURCE_ID, SERVER, "creds", "po", "group/project", "project");
-        WorkflowMultiBranchProject project = j.createProject(WorkflowMultiBranchProject.class, PROJECT_NAME);
-        BranchSource source = new BranchSource(sb.build());
-        source.getSource()
-                .setTraits(Arrays.asList(new BranchDiscoveryTrait(0), new OriginMergeRequestDiscoveryTrait(1)));
-        project.getSourcesList().add(source);
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        final TaskListener listener = new StreamTaskListener(out, StandardCharsets.UTF_8);
-        Set<SCMHead> scmHead = source.getSource().fetch(listener);
-        assertEquals(0, scmHead.size());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
@@ -4,20 +4,36 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 
+import com.google.common.util.concurrent.MoreExecutors;
+import hudson.model.TaskListener;
 import hudson.security.AccessControlled;
+import hudson.util.StreamTaskListener;
 import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper;
 import io.jenkins.plugins.gitlabbranchsource.helpers.Sleeper;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.Executors;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Set;
+import jenkins.branch.BranchSource;
+import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSourceOwner;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
-import org.gitlab4j.api.ProjectApi;
+import org.gitlab4j.api.MergeRequestApi;
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.Member;
+import org.gitlab4j.api.models.Project;
+import org.gitlab4j.api.ProjectApi;
+import org.gitlab4j.api.RepositoryApi;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -30,6 +46,7 @@ import org.mockito.Mockito;
 public class GitLabSCMSourceTest {
 
     private static final String SERVER = "server";
+    private static final String PROJECT_NAME = "project";
     private static final String SOURCE_ID = "id";
 
     @ClassRule
@@ -49,6 +66,37 @@ public class GitLabSCMSourceTest {
     public void tearDown() {
         utilities.close();
         sleeperMockedConstruction.close();
+    }
+
+    @Test
+    public void retrieveMRWithEmptyProjectSettings() throws GitLabApiException, IOException, InterruptedException {
+        GitLabApi gitLabApi = Mockito.mock(GitLabApi.class);
+        ProjectApi projectApi = Mockito.mock(ProjectApi.class);
+        RepositoryApi repoApi = Mockito.mock(RepositoryApi.class);
+        MergeRequestApi mrApi = Mockito.mock(MergeRequestApi.class);
+        Mockito.when(gitLabApi.getProjectApi()).thenReturn(projectApi);
+        Mockito.when(gitLabApi.getMergeRequestApi()).thenReturn(mrApi);
+        Mockito.when(gitLabApi.getRepositoryApi()).thenReturn(repoApi);
+        Mockito.when(projectApi.getProject(any())).thenReturn(new Project());
+        try (MockedStatic<GitLabHelper> utilities = Mockito.mockStatic(GitLabHelper.class); MockedStatic<Executors> executorsMockedStatic = Mockito.mockStatic(Executors.class)) {
+            utilities
+                    .when(() -> GitLabHelper.apiBuilder(any(AccessControlled.class), anyString(), anyString()))
+                    .thenReturn(gitLabApi);
+            executorsMockedStatic.when(null).thenReturn(
+                MoreExecutors.directExecutor());
+            GitLabServers.get().addServer(new GitLabServer("", SERVER, ""));
+            GitLabSCMSourceBuilder sb =
+                    new GitLabSCMSourceBuilder(SOURCE_ID, SERVER, "creds", "po", "group/project", "project");
+            WorkflowMultiBranchProject project = j.createProject(WorkflowMultiBranchProject.class, PROJECT_NAME);
+            BranchSource source = new BranchSource(sb.build());
+            source.getSource()
+                    .setTraits(Arrays.asList(new BranchDiscoveryTrait(0), new OriginMergeRequestDiscoveryTrait(1)));
+            project.getSourcesList().add(source);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            final TaskListener listener = new StreamTaskListener(out, StandardCharsets.UTF_8);
+            Set<SCMHead> scmHead = source.getSource().fetch(listener);
+            assertEquals(0, scmHead.size());
+        }
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
@@ -9,16 +9,15 @@ import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper;
 import io.jenkins.plugins.gitlabbranchsource.helpers.Sleeper;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
-
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import jenkins.scm.api.SCMSourceOwner;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.ProjectApi;
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.Member;
-import org.gitlab4j.api.ProjectApi;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;

--- a/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceTest.java
@@ -2,22 +2,39 @@ package io.jenkins.plugins.gitlabbranchsource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 
+import hudson.model.TaskListener;
 import hudson.security.AccessControlled;
+import hudson.util.StreamTaskListener;
 import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper;
 import io.jenkins.plugins.gitlabbranchsource.helpers.Sleeper;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServers;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import jenkins.branch.BranchSource;
+import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSourceOwner;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.MergeRequestApi;
 import org.gitlab4j.api.ProjectApi;
+import org.gitlab4j.api.RepositoryApi;
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.Member;
+import org.gitlab4j.api.models.Project;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -30,6 +47,7 @@ import org.mockito.Mockito;
 public class GitLabSCMSourceTest {
 
     private static final String SERVER = "server";
+    private static final String PROJECT_NAME = "project";
     private static final String SOURCE_ID = "id";
 
     @ClassRule
@@ -49,6 +67,49 @@ public class GitLabSCMSourceTest {
     public void tearDown() {
         utilities.close();
         sleeperMockedConstruction.close();
+    }
+
+    @Test
+    public void retrieveMRWithEmptyProjectSettings() throws GitLabApiException, IOException, InterruptedException {
+        GitLabApi gitLabApi = Mockito.mock(GitLabApi.class);
+        ProjectApi projectApi = Mockito.mock(ProjectApi.class);
+        RepositoryApi repoApi = Mockito.mock(RepositoryApi.class);
+        MergeRequestApi mrApi = Mockito.mock(MergeRequestApi.class);
+        Mockito.when(gitLabApi.getProjectApi()).thenReturn(projectApi);
+        Mockito.when(gitLabApi.getMergeRequestApi()).thenReturn(mrApi);
+        Mockito.when(gitLabApi.getRepositoryApi()).thenReturn(repoApi);
+        Mockito.when(projectApi.getProject(any())).thenReturn(new Project());
+
+        // Create a Synchronous Executor Mock
+        ExecutorService syncExecutor = Mockito.mock(ExecutorService.class);
+        Mockito.when(syncExecutor.submit(any(Runnable.class))).thenAnswer(invocation -> {
+            Runnable task = (Runnable) invocation.getArgument(0);
+            task.run();
+            Future<?> completedFuture = Mockito.mock(Future.class);
+            Mockito.when(completedFuture.get()).thenReturn(null);
+            Mockito.when(completedFuture.get(anyLong(), any(java.util.concurrent.TimeUnit.class)))
+                    .thenReturn(null);
+            return completedFuture;
+        });
+
+        try (MockedStatic<Executors> executorsMockedStatic = Mockito.mockStatic(Executors.class)) {
+            utilities
+                    .when(() -> GitLabHelper.apiBuilder(any(AccessControlled.class), anyString(), anyString()))
+                    .thenReturn(gitLabApi);
+            executorsMockedStatic.when(Executors::newSingleThreadExecutor).thenReturn(syncExecutor);
+            GitLabServers.get().addServer(new GitLabServer("", SERVER, ""));
+            GitLabSCMSourceBuilder sb =
+                    new GitLabSCMSourceBuilder(SOURCE_ID, SERVER, "creds", "po", "group/project", "project");
+            WorkflowMultiBranchProject project = j.createProject(WorkflowMultiBranchProject.class, PROJECT_NAME);
+            BranchSource source = new BranchSource(sb.build());
+            source.getSource()
+                    .setTraits(Arrays.asList(new BranchDiscoveryTrait(0), new OriginMergeRequestDiscoveryTrait(1)));
+            project.getSourcesList().add(source);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            final TaskListener listener = new StreamTaskListener(out, StandardCharsets.UTF_8);
+            Set<SCMHead> scmHead = source.getSource().fetch(listener);
+            assertEquals(0, scmHead.size());
+        }
     }
 
     @Test


### PR DESCRIPTION
### Description of Changes

Picking up work from @arechavarria in #458 that's become stale to address https://github.com/jenkinsci/gitlab-branch-source-plugin/issues/270. Rebased to pick up latest changes and addressed comments in original PR. Also fixed an authentication context regression probably caused by one of the required plugin upgrades post-rebase.

<!-- Please describe your pull request here. -->

This pull request introduces a configurable `indexingTimeout` parameter to the `gitlab-branch-source` plugin in Jenkins, enabling users to set a maximum wait time in seconds for indexing GitLab repositories. This timeout is applied in two key methods:

* `retrieve(SCMHead head, TaskListener listener)`: Updated to use an `ExecutorService` and `Future`, allowing the operation to be cancelled if it exceeds the specified timeout.
* `retrieveActions(SCMSourceCriteria criteria, SCMHeadObserver observer, SCMHeadEvent<?> event, TaskListener listener)`: Modified to respect the indexingTimeout configuration across the indexing process, including checks on branches, merge requests, and tags.
Additionally, a new `indexingTimeout` property has been added to the UI configuration in the `config-detail.jelly` file, enabling users to set the timeout through Jenkins' interface.

<img width="1914" height="858" alt="image" src="https://github.com/user-attachments/assets/ee2c4fb4-ae2b-4f74-846b-81a5a0cbf44d" />


### Testing done
Manual tests were conducted to validate `indexingTimeout` functionality in various scenarios:

Defined Timeout (greater than 0): A sample timeout was set, and it was verified that the operation would be interrupted if it exceeded the specified time.

<img width="1914" height="858" alt="image" src="https://github.com/user-attachments/assets/50fa9f35-8054-406c-b4d5-b40c5b1a2501" />

Undefined Timeout (0): Confirmed that the operation continued without interruption when `indexingTimeout` was set to 0.

<img width="1914" height="858" alt="image" src="https://github.com/user-attachments/assets/437e7464-97f9-4d6b-9d16-1bbc309af24b" />

Regression: Tested across different projects and merge requests to ensure the new functionality did not interfere with standard GitLab indexing.


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
