### PR TITLE
New branch discovery strategy: only explicitly listed

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ The following behaviours apply to both `Multibranch Pipeline Jobs` and `Folder O
 
 	* `Only Branches that are not also filed as MRs` - If you are discovering origin merge requests, it may not make sense to discover the same changes both as a merge request and as a branch.
 	* `Only Branches that are filed as MRs` - This option exists to preserve legacy behaviour when upgrading from older versions of the plugin. NOTE: If you have an actual use case for this option please file a merge request against this text.
+    * `Only explicitly listed branches` - Only branches matching the "Branches to always include" regex are built as branches. Useful when builing only long-lived branches (e.g. `main`) and MRs (discovered separately).
 	* `All Branches` - Ignores whether the branch is also filed as a merge request and instead discovers all branches on the origin project.
 
 * `Discover merge requests from origin` - To discover merge requests made from origin branches.

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/BranchDiscoveryTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/BranchDiscoveryTrait.java
@@ -253,9 +253,10 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
     }
 
     /**
-     * Filter that excludes branches that are also filed as a merge request.
+     * Base class for branch filters that support an always-included regex.
+     * Handles the common filter then delegates to {@link #isExcludedBranch} for strategy-specific logic.
      */
-    public static class ExcludeOriginMRBranchesSCMHeadFilter extends SCMHeadFilter {
+    public abstract static class BranchDiscoverySCMHeadFilter extends SCMHeadFilter {
 
         /**
          * The compiled {@link Pattern} of the branchesAlwaysIncludedRegex.
@@ -267,7 +268,7 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
          *
          * @param branchesAlwaysIncludedRegexPattern the branchesAlwaysIncludedRegexPattern.
          */
-        public ExcludeOriginMRBranchesSCMHeadFilter(Pattern branchesAlwaysIncludedRegexPattern) {
+        protected BranchDiscoverySCMHeadFilter(Pattern branchesAlwaysIncludedRegexPattern) {
             this.branchesAlwaysIncludedRegexPattern = branchesAlwaysIncludedRegexPattern;
         }
 
@@ -275,15 +276,42 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
          * {@inheritDoc}
          */
         @Override
-        public boolean isExcluded(@NonNull SCMSourceRequest request, @NonNull SCMHead head) {
-            if (head instanceof BranchSCMHead && request instanceof GitLabSCMSourceRequest) {
-                if (branchesAlwaysIncludedRegexPattern != null
-                        && branchesAlwaysIncludedRegexPattern
-                                .matcher(head.getName())
-                                .matches()) {
-                    return false;
-                }
+        public final boolean isExcluded(@NonNull SCMSourceRequest request, @NonNull SCMHead head) {
+            if (!(head instanceof BranchSCMHead)) {
+                return false;
+            }
+            if (branchesAlwaysIncludedRegexPattern != null
+                    && branchesAlwaysIncludedRegexPattern
+                            .matcher(head.getName())
+                            .matches()) {
+                return false;
+            }
+            return isExcludedBranch(request, (BranchSCMHead) head);
+        }
 
+        /**
+         * Strategy-specific exclusion logic, called only for branch heads not covered by
+         * the always-included regex.
+         *
+         * @param request the current SCM source request.
+         * @param head    the branch head being evaluated.
+         * @return {@code true} if the branch should be excluded from discovery.
+         */
+        protected abstract boolean isExcludedBranch(@NonNull SCMSourceRequest request, @NonNull BranchSCMHead head);
+    }
+
+    /**
+     * Filter that excludes branches that are also filed as a merge request.
+     */
+    public static class ExcludeOriginMRBranchesSCMHeadFilter extends BranchDiscoverySCMHeadFilter {
+
+        public ExcludeOriginMRBranchesSCMHeadFilter(Pattern branchesAlwaysIncludedRegexPattern) {
+            super(branchesAlwaysIncludedRegexPattern);
+        }
+
+        @Override
+        protected boolean isExcludedBranch(@NonNull SCMSourceRequest request, @NonNull BranchSCMHead head) {
+            if (request instanceof GitLabSCMSourceRequest) {
                 for (MergeRequest m : ((GitLabSCMSourceRequest) request).getMergeRequests()) {
                     // only match if the merge request is an origin merge request
                     if (m.getSourceProjectId().equals(m.getTargetProjectId())
@@ -299,35 +327,15 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
     /**
      * Filter that excludes branches that are not also filed as a merge request.
      */
-    public static class OnlyOriginMRBranchesSCMHeadFilter extends SCMHeadFilter {
+    public static class OnlyOriginMRBranchesSCMHeadFilter extends BranchDiscoverySCMHeadFilter {
 
-        /**
-         * The compiled {@link Pattern} of the branchesAlwaysIncludedRegex.
-         */
-        private final Pattern branchesAlwaysIncludedRegexPattern;
-
-        /**
-         * Constructor
-         *
-         * @param branchesAlwaysIncludedRegexPattern the branchesAlwaysIncludedRegexPattern.
-         */
         public OnlyOriginMRBranchesSCMHeadFilter(Pattern branchesAlwaysIncludedRegexPattern) {
-            this.branchesAlwaysIncludedRegexPattern = branchesAlwaysIncludedRegexPattern;
+            super(branchesAlwaysIncludedRegexPattern);
         }
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
-        public boolean isExcluded(@NonNull SCMSourceRequest request, @NonNull SCMHead head) {
-            if (head instanceof BranchSCMHead && request instanceof GitLabSCMSourceRequest) {
-                if (branchesAlwaysIncludedRegexPattern != null
-                        && branchesAlwaysIncludedRegexPattern
-                                .matcher(head.getName())
-                                .matches()) {
-                    return false;
-                }
-
+        protected boolean isExcludedBranch(@NonNull SCMSourceRequest request, @NonNull BranchSCMHead head) {
+            if (request instanceof GitLabSCMSourceRequest) {
                 for (MergeRequest m : ((GitLabSCMSourceRequest) request).getMergeRequests()) {
                     if (m.getSourceProjectId().equals(m.getTargetProjectId())
                             && !m.getSourceBranch().equalsIgnoreCase(head.getName())) {
@@ -342,37 +350,15 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
     /**
      * Filter that excludes all branches except those matching the always-included regex.
      */
-    public static class OnlyExplicitlyListedBranchesSCMHeadFilter extends SCMHeadFilter {
+    public static class OnlyExplicitlyListedBranchesSCMHeadFilter extends BranchDiscoverySCMHeadFilter {
 
-        /**
-         * The compiled {@link Pattern} of the branchesAlwaysIncludedRegex.
-         */
-        private final Pattern branchesAlwaysIncludedRegexPattern;
-
-        /**
-         * Constructor
-         *
-         * @param branchesAlwaysIncludedRegexPattern the branchesAlwaysIncludedRegexPattern.
-         */
         public OnlyExplicitlyListedBranchesSCMHeadFilter(Pattern branchesAlwaysIncludedRegexPattern) {
-            this.branchesAlwaysIncludedRegexPattern = branchesAlwaysIncludedRegexPattern;
+            super(branchesAlwaysIncludedRegexPattern);
         }
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
-        public boolean isExcluded(@NonNull SCMSourceRequest request, @NonNull SCMHead head) {
-            if (head instanceof BranchSCMHead) {
-                if (branchesAlwaysIncludedRegexPattern != null
-                        && branchesAlwaysIncludedRegexPattern
-                                .matcher(head.getName())
-                                .matches()) {
-                    return false;
-                }
-                return true;
-            }
-            return false;
+        protected boolean isExcludedBranch(@NonNull SCMSourceRequest request, @NonNull BranchSCMHead head) {
+            return true;
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/BranchDiscoveryTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/BranchDiscoveryTrait.java
@@ -143,6 +143,9 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
                 ctx.wantOriginMRs(true);
                 ctx.withFilter(new OnlyOriginMRBranchesSCMHeadFilter(getBranchesAlwaysIncludedRegexPattern()));
                 break;
+            case 4:
+                ctx.withFilter(new OnlyExplicitlyListedBranchesSCMHeadFilter(getBranchesAlwaysIncludedRegexPattern()));
+                break;
             case 3:
             default:
                 // we don't care if it is a MR or not, we're taking them all, no need to ask for MRs and no need
@@ -204,6 +207,7 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
             ListBoxModel result = new ListBoxModel();
             result.add(Messages.BranchDiscoveryTrait_excludeMRs(), "1");
             result.add(Messages.BranchDiscoveryTrait_onlyMRs(), "2");
+            result.add(Messages.BranchDiscoveryTrait_onlyExplicitlyListed(), "4");
             result.add(Messages.BranchDiscoveryTrait_allBranches(), "3");
             return result;
         }
@@ -330,6 +334,43 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
                         return true;
                     }
                 }
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Filter that excludes all branches except those matching the always-included regex.
+     */
+    public static class OnlyExplicitlyListedBranchesSCMHeadFilter extends SCMHeadFilter {
+
+        /**
+         * The compiled {@link Pattern} of the branchesAlwaysIncludedRegex.
+         */
+        private final Pattern branchesAlwaysIncludedRegexPattern;
+
+        /**
+         * Constructor
+         *
+         * @param branchesAlwaysIncludedRegexPattern the branchesAlwaysIncludedRegexPattern.
+         */
+        public OnlyExplicitlyListedBranchesSCMHeadFilter(Pattern branchesAlwaysIncludedRegexPattern) {
+            this.branchesAlwaysIncludedRegexPattern = branchesAlwaysIncludedRegexPattern;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean isExcluded(@NonNull SCMSourceRequest request, @NonNull SCMHead head) {
+            if (head instanceof BranchSCMHead) {
+                if (branchesAlwaysIncludedRegexPattern != null
+                        && branchesAlwaysIncludedRegexPattern
+                                .matcher(head.getName())
+                                .matches()) {
+                    return false;
+                }
+                return true;
             }
             return false;
         }

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/BranchDiscoveryTrait/help-strategyId.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/BranchDiscoveryTrait/help-strategyId.html
@@ -20,5 +20,9 @@
       on the
       origin project.
     </dd>
+    <dt>Only explicitly listed branches</dt>
+    <dd>
+      Only branches matching the "Branches to always include" regex are built as branches.
+    </dd>
   </dl>
 </div>

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
@@ -4,6 +4,7 @@ BranchDiscoveryTrait.authorityDisplayName=Trust origin branches
 BranchDiscoveryTrait.displayName=Discover branches
 BranchDiscoveryTrait.excludeMRs=Only branches that are not also filed as MRs
 BranchDiscoveryTrait.onlyMRs=Only branches that are also filed as MRs
+BranchDiscoveryTrait.onlyExplicitlyListed=Only explicitly listed branches
 ExcludeArchivedRepositoriesTrait.displayName=Exclude archived repositories
 BuildStatusNameCustomPartTrait.displayName=Customize GitLab build status name
 ForkMergeRequestDiscoveryTrait.displayName=Discover merge requests from forks


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Use case: I want to build only "main" branch and MRs. Existing "Only Branches that are filed as MRs" strategy has built-in bug - it does build branch when there's only one MR. It might be required by it being "legacy" (I've filled issue https://github.com/jenkinsci/gitlab-branch-source-plugin/issues/761). This MR adds new strategy that filters out all branches except for the ones matching the regex pattern. 

As part of the MR I've also extracted duplicated pattern checking code to the base class. 

I think that this strategy could replace "Only Branches that are filed as MRs", because it looks like the strategy that one was supposed to be (they behave the same when there are more than one MR, or to be precise - MRs with various source branches). But maybe the "legacy behaviour" is important. Let me know - I can change the PR to _replace_ old strategy.

### Testing done

My local instance of the Jenkins runs with the option enabled and it works as expected:

<img width="295" height="160" alt="image" src="https://github.com/user-attachments/assets/a82a25b0-b49a-4577-acf6-a1492245e2e7" />

<img width="351" height="128" alt="image" src="https://github.com/user-attachments/assets/6524d086-7cd3-423b-badf-eb07c8ca26d8" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
