### PR TITLE
[JENKINS-75902] Always save a timestamp of the latest GitLab project configurations into the config, signalling this plugin has done some work

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -120,6 +120,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     private String httpRemote;
     private transient Project gitlabProject;
     private Long projectId;
+    private Long lastRetrieveTimestamp;
 
     private static final Integer MAX_RETRIES = 5;
 
@@ -171,6 +172,14 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
 
     public void setSshRemote(String sshRemote) {
         this.sshRemote = sshRemote;
+    }
+
+    public Long getLastRetrieveTimestamp() {
+        return lastRetrieveTimestamp;
+    }
+
+    public void setLastRetrieveTimestamp(Long lastRetrieveTimestamp) {
+        this.lastRetrieveTimestamp = lastRetrieveTimestamp;
     }
 
     public String getProjectName() {
@@ -312,11 +321,45 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         this.traits = new ArrayList<>(Util.fixNull(traits));
     }
 
+    /**
+     * Saves the current state of this object into a configuration file.
+     *
+     * @throws IOException When saving into the file fails.
+     */
+    private void saveOwner() throws IOException {
+        SCMSourceOwner owner = this.getOwner();
+        if (owner != null) {
+            owner.save();
+        }
+    }
+
+    /**
+     * When the jobDSL plugin is called, one of the retrieve() methods ends up being called.
+     * When those methods fail to communicate with GitLab, the config.xml file corresponding to
+     * the pipeline being analysed is not saved.
+     * Later, the jobDSL only calls those methods to update the configurations when there are
+     * changes to the configuration.
+     * <p/>
+     * Because in the above case, the config didn't change, these retrieve() methods are never
+     * called again.
+     * We force the saving of a timestamp to make sure _something_ is written in the config at
+     * all times (and the jobDSL plugin doesn't see it as being unnecessary to resync)
+     * and future reattempts are allowed.
+     *
+     * @throws IOException When saving into the file fails.
+     */
+    private void saveTimestampInOwner() throws IOException {
+        setLastRetrieveTimestamp(System.currentTimeMillis());
+        saveOwner();
+    }
+
     @Override
-    protected SCMRevision retrieve(@NonNull SCMHead head, @NonNull TaskListener listener)
-            throws IOException, InterruptedException {
+    protected SCMRevision retrieve(@NonNull SCMHead head, @NonNull TaskListener listener) throws IOException {
+        saveTimestampInOwner();
+
+        GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName, credentialsId);
+
         try {
-            GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName, credentialsId);
             getGitlabProject(gitLabApi);
             if (head instanceof BranchSCMHead) {
                 listener.getLogger().format("Querying the current revision of branch %s...%n", head.getName());
@@ -377,6 +420,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             SCMHeadEvent<?> event,
             @NonNull TaskListener listener)
             throws IOException, InterruptedException {
+        saveTimestampInOwner();
+
         GitLabApi gitLabApi = apiBuilder(this.getOwner(), serverName, credentialsId);
         try {
             getGitlabProject(gitLabApi);
@@ -636,10 +681,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             LOGGER.log(Level.WARNING, "Exception caught:" + e, e);
             throw new IOException("Failed to fetch latest heads", e);
         } finally {
-            SCMSourceOwner owner = this.getOwner();
-            if (owner != null) {
-                owner.save();
-            }
+            saveOwner();
         }
     }
 
@@ -665,6 +707,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     @NonNull
     @Override
     protected List<Action> retrieveActions(SCMSourceEvent event, @NonNull TaskListener listener) throws IOException {
+        saveTimestampInOwner();
+
         List<Action> result = new ArrayList<>();
         try {
             getGitlabProject();
@@ -688,6 +732,8 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
     @Override
     protected List<Action> retrieveActions(@NonNull SCMHead head, SCMHeadEvent event, @NonNull TaskListener listener)
             throws IOException {
+        saveTimestampInOwner();
+
         try {
             getGitlabProject();
         } catch (GitLabApiException e) {


### PR DESCRIPTION
This change continues the work done in https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/495 and carries over from the PR that was open in https://github.com/Pitxyoki/gitlab-branch-source-plugin/pull/1.

We found that this plugins' `GitLabSCMSource#retrieve()` methods are called when the job-dsl-plugin's `jobDsl()` method is called.
If at those points the code in this plugin fails to communicate with GitLab, the `config.xml` file corresponding to the pipeline being parsed is saved without any information that would come from this project's GitLab project (i.e.: `sshRemote`, `httpRemote`, `projectId` will not exist). The contents of that file will be the same as if this plugin hadn't executed.

When the `jobDsl()` method is called again at a later time, it compares the saved `config.xml` to the `config.xml` it expects to save at that point. See https://github.com/jenkinsci/job-dsl-plugin/blob/master/job-dsl-plugin/src/main/java/javaposse/jobdsl/plugin/JenkinsJobManagement.java#L453.
Note that at that point, the new expected `config.xml` that the job-dsl-plugin uses for that diff does not have any information that should come from the gitlab-branch-source-plugin.
As such, at that point both the base `config.xml` as well as the expected-to-save `config.xml` are equal.

This change adds a new field to the pipeline's configuration, `lastRetrieveTimestamp`, that is updated at every attempt to update it, regardless of the GitLab communication having succeeded or not. In this way, the attempted `diff` by the job-dsl-plugin will always trigger an update and corresponding reattempt at communicating with GitLab, preventing previous failures from avoiding that.

### Testing done

Similarly to https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/495, we deployed a patched gitlab-branch-source-plugin with both that and this change into our running Jenkins in July 2025. It has been more than 1 year now and we have not seen the issue reoccurring.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed